### PR TITLE
Improve autofocus reengagement

### DIFF
--- a/mantis/acquisition/microscope_operations.py
+++ b/mantis/acquisition/microscope_operations.py
@@ -207,9 +207,10 @@ def autofocus(mmc, mmStudio, z_stage_name: str, z_position):
         for z_offset in z_offsets:
             mmc.set_position(z_stage_name, z_position + z_offset)
             mmc.wait_for_device(z_stage_name)
-            time.sleep(1)  # wait an extra second
 
             af_method.enable_continuous_focus(True)  # this call engages autofocus
+            time.sleep(1)  # wait an extra second
+
             if af_method.is_continuous_focus_locked():
                 autofocus_success = True
                 break


### PR DESCRIPTION
This PR improves the autofocus re-enragement rate when arriving at a new well from ~ 65% to ~100% without increasing the acquisition time. This PR has been tested and is ready to merge.

As an experimental detail, imaging over a long time period works better when using the 12500 cSt silicone oil. I observed that even the 1000 cSt we currently use drips over time to the point where there is not enough oil on the plate to engage with the objective.

fixes #31 