### PR TITLE
Affine scaling fix

### DIFF
--- a/mantis/cli/apply_affine.py
+++ b/mantis/cli/apply_affine.py
@@ -37,6 +37,10 @@ def rotate_n_affine_transform(
     return affine_volume
 
 
+def apply_affine_to_scale(affine_matrix, input_scale):
+    return np.linalg.norm(affine_matrix, axis=1) * input_scale
+
+
 @click.command()
 @input_position_dirpaths()
 @config_filepath()
@@ -76,9 +80,7 @@ def apply_affine(
 
     # Calculate the output voxel size from the input scale and affine transform
     with open_ome_zarr(input_position_dirpaths[0]) as input_dataset:
-        input_voxel_size = np.array(input_dataset.scale[-3:])
-    affine_scaling = np.abs(np.linalg.eig(matrix[:3, :3])[0])[::-1]
-    output_voxel_size = affine_scaling * input_voxel_size
+        output_voxel_size = apply_affine_to_scale(matrix[:3,:3], input_dataset.scale[-3:])
 
     click.echo('\nREGISTRATION PARAMETERS:')
     click.echo(f'Affine transform: {matrix}')

--- a/mantis/tests/test_cli/test_apply_affine_cli.py
+++ b/mantis/tests/test_cli/test_apply_affine_cli.py
@@ -1,5 +1,9 @@
-from click.testing import CliRunner
+import numpy as np
 
+from click.testing import CliRunner
+from numpy import testing
+
+from mantis.cli.apply_affine import apply_affine_to_scale
 from mantis.cli.main import cli
 
 
@@ -25,3 +29,36 @@ def test_apply_affine_cli(tmp_path, example_plate, example_apply_affine_settings
 
     assert output_path.exists()
     assert result.exit_code == 0
+
+
+def test_apply_affine_to_scale():
+    input = np.array([1, 1, 1])
+
+    # Test real positive
+    m1_diag = np.array([2, 3, 4])
+    m1 = np.diag(m1_diag)
+    output1 = apply_affine_to_scale(m1, input)
+    testing.assert_allclose(m1_diag, output1)
+
+    # Test real with negative
+    m2_diag = np.array([2, -3, 4])
+    m2 = np.diag(m2_diag)
+    output2 = apply_affine_to_scale(m2, input)
+    testing.assert_allclose(np.abs(m2_diag), output2)
+
+    # Test transpose
+    m3 = np.array([[0, 2, 0], [1, 0, 0], [0, 0, 3]])
+    output3 = apply_affine_to_scale(m3, input)
+    testing.assert_allclose(np.array([2, 1, 3]), output3)
+
+    # Test rotation
+    theta = np.pi / 3
+    m4 = np.array(
+        [
+            [2, 0, 0],
+            [0, 3 * np.cos(theta), -3 * np.sin(theta)],
+            [0, 3 * np.sin(theta), 3 * np.cos(theta)],
+        ]
+    )
+    output4 = apply_affine_to_scale(m4, input)
+    testing.assert_allclose(np.array([2, 3, 3]), output4)


### PR DESCRIPTION
@edyoshikun it seems like my on-the-fly affine scaling implementation was buggy (I saw your [::-1]). I'm fairly certain the bugs were caused by `np.linalg.eig` returning unordered eigenvalues . 

Here I'm suggesting a much simpler (and tested) version. Note the PR is against `replace_zstep_global`. 