### PR TITLE
Move logger config to mantis/__init__.py and rename to `mantis`

### DIFF
--- a/mantis/__init__.py
+++ b/mantis/__init__.py
@@ -1,2 +1,21 @@
+import logging
+
 __version__ = "0.1.0"
 __mm_version__ = "2023-08-07"
+
+
+# Define logging console handler
+def get_console_handler():
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(logging.INFO)
+    console_format = logging.Formatter('%(levelname)s - %(module)s.%(funcName)s - %(message)s')
+    console_handler.setFormatter(console_format)
+    return console_handler
+
+
+# Setup logger
+logger = logging.getLogger('mantis')
+logger.setLevel(logging.DEBUG)
+
+logger.addHandler(get_console_handler())
+logger.propagate = False

--- a/mantis/acquisition/acq_engine.py
+++ b/mantis/acquisition/acq_engine.py
@@ -19,7 +19,7 @@ from waveorder.focus import focus_from_transverse_band
 
 from mantis.acquisition import microscope_operations
 from mantis.acquisition.hook_functions import config
-from mantis.acquisition.logger import configure_logger, log_conda_environment
+from mantis.acquisition.logger import configure_debug_logger, log_conda_environment
 
 # isort: off
 from mantis.acquisition.AcquisitionSettings import (
@@ -316,7 +316,7 @@ class MantisAcquisition(object):
         # Setup logger
         timestamp = datetime.now().strftime("%Y%m%dT%H%M%S")
         acq_log_path = self._logs_dir / f'mantis_acquisition_log_{timestamp}.txt'
-        configure_logger(acq_log_path)
+        configure_debug_logger(acq_log_path)
 
         if self._demo_run:
             logger.info('NOTE: This is a demo run')

--- a/mantis/acquisition/logger.py
+++ b/mantis/acquisition/logger.py
@@ -6,6 +6,25 @@ from subprocess import PIPE, STDOUT, Popen
 from typing import Union
 
 
+def configure_debug_logger(filepath: str, logger_name: str = 'mantis'):
+    """Add a file handler at DEBUG level for a given logger
+
+    Parameters
+    ----------
+    filepath : str
+        Debug log file path
+    logger_name : str, optional
+        Logger name, by default 'mantis'
+    """
+    file_handler = logging.FileHandler(filepath)
+    file_handler.setLevel(logging.DEBUG)
+    file_format = logging.Formatter(
+        '%(asctime)s - %(levelname)s - %(module)s.%(funcName)s - %(message)s'
+    )
+    file_handler.setFormatter(file_format)
+    logging.getLogger(logger_name).addHandler(file_handler)
+
+
 def log_conda_environment(log_path: Union[str, os.PathLike]):
     """Save a log of the current conda environment as defined in the
     `compmicro-docs/hpc/log_environment.ps1` PowerShell script. A copy of the
@@ -42,33 +61,3 @@ def log_conda_environment(log_path: Union[str, os.PathLike]):
     output, errors = process.communicate()
 
     return output, errors
-
-
-# Setup console handler
-def get_console_handler():
-    console_handler = logging.StreamHandler()
-    console_handler.setLevel(logging.INFO)
-    console_format = logging.Formatter('%(levelname)s - %(module)s.%(funcName)s - %(message)s')
-    console_handler.setFormatter(console_format)
-    return console_handler
-
-
-# Setup file handler
-def get_file_handler(filename):
-    file_handler = logging.FileHandler(filename)
-    file_handler.setLevel(logging.DEBUG)
-    file_format = logging.Formatter(
-        '%(asctime)s - %(levelname)s - %(module)s.%(funcName)s - %(message)s'
-    )
-    file_handler.setFormatter(file_format)
-    return file_handler
-
-
-# Setup root logger
-def configure_logger(filename):
-    logger = logging.getLogger()
-    logger.setLevel(logging.DEBUG)
-
-    logger.addHandler(get_console_handler())
-    logger.addHandler(get_file_handler(filename))
-    logger.propagate = False


### PR DESCRIPTION
Fixes #61 

This PR moves away from using the root logger. The logger is now initialized together with the mantis module with a INFO level console handler. The DEGUB level file handler is adding with the init of the acquisition engine, as before (once we know where the log file should be saved). This PR will also allow for more robust reuse of the longer in analysis modules. 