### PR TITLE
Only move stage when going to different position

### DIFF
--- a/mantis/acquisition/acq_engine.py
+++ b/mantis/acquisition/acq_engine.py
@@ -1022,6 +1022,7 @@ class MantisAcquisition(object):
         logger.info('Starting acquisition')
         ls_o3_refocus_time = time.time()
         previous_well_id = None
+        previous_position_label = None
         for t_idx in range(self.time_settings.num_timepoints):
             timepoint_start_time = time.time()
             for p_idx in range(self.position_settings.num_positions):
@@ -1029,7 +1030,8 @@ class MantisAcquisition(object):
                 well_id = self.position_settings.well_ids[p_idx]
 
                 # move to the given position
-                self.go_to_position(p_idx)
+                if p_label != previous_position_label:
+                    self.go_to_position(p_idx)
 
                 # autofocus
                 if self.lf_acq.microscope_settings.use_autofocus:
@@ -1123,6 +1125,7 @@ class MantisAcquisition(object):
                 if ls_acq_aborted:
                     logger.error(error_message.format('Light-sheet', t_idx, p_label))
                 previous_well_id = well_id
+                previous_position_label = p_label
                 globals.new_well = False
 
             # wait for time interval between time points


### PR DESCRIPTION
Only move stage when going to different position, as determined from the position label. This bug caused jitter in our A549 movies from 2023/09/22 where we imaged a single position over multiple timepoints with the stage adjusting its position for every timepoint.