### PR TITLE
GPU deskew

### DIFF
--- a/mantis/analysis/deskew.py
+++ b/mantis/analysis/deskew.py
@@ -1,7 +1,8 @@
 import numpy as np
-from monai.transforms.spatial.array import Affine
-from monai import transforms
 import torch
+
+from monai import transforms
+from monai.transforms.spatial.array import Affine
 
 
 def _average_n_slices(data, average_window_width=1):

--- a/mantis/analysis/deskew.py
+++ b/mantis/analysis/deskew.py
@@ -142,11 +142,6 @@ def deskew_data(
         If false, only compute the deskewed volume within a cuboid region.
     average_n_slices : int, optional
         after deskewing, averages every n slices (default = 1 applies no averaging)
-    order : int, optional
-        interpolation order (default 1 is linear interpolation)
-    cval : float, optional
-        fill value area outside of the measured volume (default None fills
-        with the minimum value of the input array)
     Returns
     -------
     deskewed_data : NDArray with ndim == 3
@@ -154,9 +149,6 @@ def deskew_data(
         axis 1 is the Y axis, input axis 2 in the plane of the coverslip
         axis 2 is the X axis, the scanning axis
     """
-    if cval is None:
-        cval = np.min(np.ravel(raw_data))
-
     # Prepare transforms
     Z, Y, X = raw_data.shape
 
@@ -184,7 +176,7 @@ def deskew_data(
         raw_data = transforms.ToDevice("cuda")(torch.tensor(raw_data))
 
     # Returns callable
-    affine_func = Affine(affine=matrix, mode=order, padding_mode="zeros", image_only=True)
+    affine_func = Affine(affine=matrix, padding_mode="zeros", image_only=True)
 
     # affine_func accepts CZYX array, so for ZYX input we need [None] and for ZYX output we need [0]
     deskewed_data = affine_func(raw_data[None], mode="bilinear", spatial_size=output_shape)[0]

--- a/mantis/analysis/deskew.py
+++ b/mantis/analysis/deskew.py
@@ -170,9 +170,7 @@ def deskew_data(
 
     # convert to tensor on GPU
     # convert raw_data to int32 if it is uint16
-    if raw_data.dtype == np.uint16:
-        raw_data = raw_data.astype(np.int32)
-    raw_data_tensor = torch.as_tensor(raw_data, device=device)
+    raw_data_tensor = torch.from_numpy(raw_data.astype(np.float32)).to(device)
 
     # Returns callable
     affine_func = Affine(affine=matrix, padding_mode="zeros", image_only=True)

--- a/mantis/analysis/deskew.py
+++ b/mantis/analysis/deskew.py
@@ -178,9 +178,6 @@ def deskew_data(
         raw_data.shape, ls_angle_deg, px_to_scan_ratio, keep_overhang
     )
 
-    import time 
-    start = time.time()
-
     # to tensor on GPU
     if torch.cuda.is_available():
         raw_data = transforms.ToDevice("cuda")(torch.tensor(raw_data))
@@ -194,7 +191,6 @@ def deskew_data(
     # to numpy array on CPU
     deskewed_data = deskewed_data.cpu().numpy()
 
-    print(f"Elapsed: {time.time() - start:.2f}")
     # Apply averaging
     averaged_deskewed_data = _average_n_slices(
         deskewed_data, average_window_width=average_n_slices

--- a/mantis/analysis/deskew.py
+++ b/mantis/analysis/deskew.py
@@ -187,6 +187,21 @@ def deskew_data(
         cval=cval,
     )
 
+    from monai.transforms.spatial.array import Affine
+
+    print("Computing w/ MONAI...")
+    my_matrix = np.vstack((matrix, np.array([[0, 0, 0, 1]])))
+    my_affine = Affine(
+        affine=my_matrix, mode="bilinear", padding_mode="zeros", image_only=True
+    )
+    deskewed_data2 = my_affine(raw_data[None], spatial_size=output_shape)[0]
+
+    print(deskewed_data)
+    print(deskewed_data2)
+    import pdb
+
+    pdb.set_trace()
+
     # Apply averaging
     averaged_deskewed_data = _average_n_slices(
         deskewed_data, average_window_width=average_n_slices

--- a/mantis/analysis/deskew.py
+++ b/mantis/analysis/deskew.py
@@ -118,7 +118,7 @@ def deskew_data(
     px_to_scan_ratio: float,
     keep_overhang: bool,
     average_n_slices: int = 1,
-    device='cpu'
+    device='cpu',
 ):
     """Deskews fluorescence data from the mantis microscope
     Parameters
@@ -178,7 +178,9 @@ def deskew_data(
     affine_func = Affine(affine=matrix, padding_mode="zeros", image_only=True)
 
     # affine_func accepts CZYX array, so for ZYX input we need [None] and for ZYX output we need [0]
-    deskewed_data = affine_func(raw_data_tensor[None], mode="bilinear", spatial_size=output_shape)[0]
+    deskewed_data = affine_func(
+        raw_data_tensor[None], mode="bilinear", spatial_size=output_shape
+    )[0]
 
     # to numpy array on CPU
     deskewed_data = deskewed_data.cpu().numpy()

--- a/mantis/analysis/deskew.py
+++ b/mantis/analysis/deskew.py
@@ -1,7 +1,6 @@
 import numpy as np
 import torch
 
-from monai import transforms
 from monai.transforms.spatial.array import Affine
 
 
@@ -173,7 +172,7 @@ def deskew_data(
 
     # to tensor on GPU
     if torch.cuda.is_available():
-        raw_data = transforms.ToDevice("cuda")(torch.tensor(raw_data))
+        raw_data = torch.tensor(raw_data).to("cuda")
 
     # Returns callable
     affine_func = Affine(affine=matrix, padding_mode="zeros", image_only=True)

--- a/mantis/cli/deskew.py
+++ b/mantis/cli/deskew.py
@@ -4,9 +4,6 @@ from pathlib import Path
 from typing import List
 
 import click
-
-# Needed for multiprocessing with GPUs
-# https://github.com/pytorch/pytorch/issues/40403#issuecomment-1422625325
 import torch
 
 from iohub.ngff import open_ome_zarr
@@ -17,6 +14,8 @@ from mantis.cli import utils
 from mantis.cli.parsing import config_filepath, input_position_dirpaths, output_dirpath
 from mantis.cli.utils import yaml_to_model
 
+# Needed for multiprocessing with GPUs
+# https://github.com/pytorch/pytorch/issues/40403#issuecomment-1422625325
 torch.multiprocessing.set_start_method('spawn', force=True)
 
 

--- a/mantis/cli/deskew.py
+++ b/mantis/cli/deskew.py
@@ -94,5 +94,6 @@ def deskew(
             **deskew_args,
         )
 
+
 if __name__ == "__main__":
     deskew()

--- a/mantis/cli/deskew.py
+++ b/mantis/cli/deskew.py
@@ -5,6 +5,10 @@ from typing import List
 
 import click
 
+# Needed for multiprocessing with GPUs
+# https://github.com/pytorch/pytorch/issues/40403#issuecomment-1422625325
+import torch
+
 from iohub.ngff import open_ome_zarr
 
 from mantis.analysis.AnalysisSettings import DeskewSettings
@@ -12,10 +16,6 @@ from mantis.analysis.deskew import deskew_data, get_deskewed_data_shape
 from mantis.cli import utils
 from mantis.cli.parsing import config_filepath, input_position_dirpaths, output_dirpath
 from mantis.cli.utils import yaml_to_model
-
-# Needed for multiprocessing with GPUs
-# https://github.com/pytorch/pytorch/issues/40403#issuecomment-1422625325
-import torch
 
 torch.multiprocessing.set_start_method('spawn', force=True)
 

--- a/mantis/cli/deskew.py
+++ b/mantis/cli/deskew.py
@@ -93,3 +93,6 @@ def deskew(
             num_processes=num_processes,
             **deskew_args,
         )
+
+if __name__ == "__main__":
+    deskew()

--- a/mantis/cli/deskew.py
+++ b/mantis/cli/deskew.py
@@ -13,6 +13,12 @@ from mantis.cli import utils
 from mantis.cli.parsing import config_filepath, input_position_dirpaths, output_dirpath
 from mantis.cli.utils import yaml_to_model
 
+# Needed for multiprocessing with GPUs
+# https://github.com/pytorch/pytorch/issues/40403#issuecomment-1422625325
+import torch
+
+torch.multiprocessing.set_start_method('spawn', force=True)
+
 
 @click.command()
 @input_position_dirpaths()

--- a/mantis/tests/test_analysis/test_deskew.py
+++ b/mantis/tests/test_analysis/test_deskew.py
@@ -26,7 +26,7 @@ def test_average_n_slices():
 
 
 def test_deskew_data():
-    raw_data = np.arange(24).reshape((2, 3, 4))
+    raw_data = np.random.random((2, 3, 4))
     px_to_scan_ratio = 0.386
     pixel_size_um = 1.0
     ls_angle_deg = 36

--- a/mantis/tests/test_analysis/test_deskew.py
+++ b/mantis/tests/test_analysis/test_deskew.py
@@ -26,7 +26,7 @@ def test_average_n_slices():
 
 
 def test_deskew_data():
-    raw_data = np.random.random((2, 3, 4))
+    raw_data = np.arange(24).reshape((2, 3, 4))
     px_to_scan_ratio = 0.386
     pixel_size_um = 1.0
     ls_angle_deg = 36

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 # list package dependencies here
 dependencies = [
   "copylot @ git+https://github.com/czbiohub-sf/coPylot",
-  "iohub==0.1.0.dev5",
+  "iohub==0.1.0",
   "matplotlib",
   "napari; 'arm64' in platform_machine",                 # without Qt5 and skimage
   "napari[all]; 'arm64' not in platform_machine",        # with Qt5 and skimage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
   "largestinteriorrectangle",
   "antspyx",
   "pystackreg",
+
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ dependencies = [
   "largestinteriorrectangle",
   "antspyx",
   "pystackreg",
-
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
   "ndtiff>=2.0",
   "nidaqmx",
   "numpy",
+  "monai",
   "pandas~=2.1",
   "pycromanager==0.28.1",
   "pydantic",


### PR DESCRIPTION
This PR changes the existing `scipy.ndimage` deskew to a GPU-accelerated `monai` deskew. 

--
**Benchmarks:**
Deskewing a 280x600x1372 argolight target takes:

(Deskewing function calls, including CPU->GPU->CPU transfers)
(Most relevant to @ieivanov's live applications)
**Before: 61 s**
**After: 5.1 s**

(Deskewing CLI calls, including IO, imports, and other overhead)
**Before: 82 s**
**After: 49 s**

-- 
**The new and old deskews do not match exactly for two reasons:** 

(1) **MONAI's GPU deskew only supports nearest-neighbor and bilinear interpolation modes**, not the linear spline interpolation that we used previously. I chose to use bilinear interpolation, and on close inspection (screenshots don't show any difference) the only differences I observe are:
- a <1 pixel shift 
- <1% interpolation differences
- minor changes in auto-contrast---interpolation differences can change the min and max, so autocontrast can change. Locking the contrast when comparing generates indistinguishable contrast. 

**@ieivanov I would appreciate your help in scrutinizing a few initial deskews as we onboard this change.**

(2) **MONAI's GPU deskew only supports filling empty values with zeros**, not the background-estimated fill that we used previously. This difference is not important because we almost always clip off the overhang, leaving no values to fill. 

You can take a closer look at my argolight tests here:
`/hpc/projects/comp.micro/mantis/2024_04_23_mantis_alignment/2-deskew/test-monai`

--

**Other notes:**
- if a GPU is unavailable, the new deskew will still succeed (slowly)
- I expect that @ieivanov's scatter-gather strategy for splitting a deskew into GPU-memory-sized chunks will still succeed.  