### PR TITLE
Fix bug in test_estimate_stabilization

### DIFF
--- a/mantis/cli/deskew.py
+++ b/mantis/cli/deskew.py
@@ -1,5 +1,3 @@
-import multiprocessing as mp
-
 from pathlib import Path
 from typing import List
 
@@ -21,7 +19,7 @@ from mantis.cli.utils import yaml_to_model
 @click.option(
     "--num-processes",
     "-j",
-    default=mp.cpu_count(),
+    default=1,
     help="Number of cores",
     required=False,
     type=int,

--- a/mantis/cli/estimate_stabilization.py
+++ b/mantis/cli/estimate_stabilization.py
@@ -163,7 +163,11 @@ def estimate_xy_stabilization(
     if (output_folder_path / "positions_focus.csv").exists():
         df = pd.read_csv(output_folder_path / "positions_focus.csv")
         pos_idx = str(Path(*input_data_path.parts[-3:]))
-        z_idx = list(df[df["position"] == pos_idx]["focus_idx"].replace(0, np.nan).ffill())
+        focus_idx = df[df["position"] == pos_idx]["focus_idx"]
+        # forward fill 0 values, when replace remaining NaN with the mean
+        focus_idx = focus_idx.replace(0, np.nan).ffill()
+        focus_idx = focus_idx.fillna(focus_idx.mean())
+        z_idx = focus_idx.astype(int).to_list()
     else:
         z_idx = [
             focus_from_transverse_band(


### PR DESCRIPTION
New call to `df.ffill()` outputs floats which need to be converted to ints for indexing