### PR TITLE
Restrict to numpy<2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "natsort",
   "ndtiff>=2.0",
   "nidaqmx",
-  "numpy",
+  "numpy<2",
   "pandas~=2.1",
   "pycromanager==0.28.1",
   "pydantic",


### PR DESCRIPTION
numpy 2.0.0 breaks tests