### PR TITLE
Bug in parallelization over t and c

### DIFF
--- a/mantis/cli/utils.py
+++ b/mantis/cli/utils.py
@@ -216,7 +216,6 @@ def apply_transform_to_zyx_and_save_v2(
         input_channel_indices = [int(x) for x in input_channel_indices if x.isdigit()]
     if _is_nested(output_channel_indices):
         output_channel_indices = [int(x) for x in output_channel_indices if x.isdigit()]
-    click.echo(f"input_channel_indices: {input_channel_indices}")
 
     # Check if t_idx should be added to the func kwargs
     # This is needed when a different processing is needed for each time point, for example during stabilization

--- a/mantis/cli/utils.py
+++ b/mantis/cli/utils.py
@@ -225,7 +225,7 @@ def apply_transform_to_zyx_and_save_v2(
         kwargs["t_idx"] = t_idx
 
     # Process CZYX vs ZYX
-    if input_channel_indices is not None:
+    if input_channel_indices is not None and len(input_channel_indices) > 0:
         click.echo(f"Processing t={t_idx}")
 
         czyx_data = position.data.oindex[t_idx, input_channel_indices]
@@ -240,15 +240,15 @@ def apply_transform_to_zyx_and_save_v2(
     else:
         click.echo(f"Processing c={c_idx}, t={t_idx}")
 
-        zyx_data = position.data.oindex[t_idx, c_idx]
+        czyx_data = position.data.oindex[t_idx, c_idx : c_idx + 1]
         # Checking if nans or zeros and skip processing
-        if not _check_nan_n_zeros(zyx_data):
+        if not _check_nan_n_zeros(czyx_data):
             # Apply transformation
-            transformed_zyx = func(zyx_data, **kwargs)
+            transformed_czyx = func(czyx_data, **kwargs)
 
             # Write to file
             with open_ome_zarr(output_path, mode="r+") as output_dataset:
-                output_dataset[0][t_idx_out, c_idx] = transformed_zyx
+                output_dataset[0][t_idx_out, c_idx : c_idx + 1] = transformed_czyx
 
             click.echo(f"Finished Writing.. c={c_idx}, t={t_idx}")
         else:
@@ -387,8 +387,8 @@ def process_single_position_v2(
             func,
             input_dataset,
             output_path / Path(*input_data_path.parts[-3:]),
-            input_channel_indices=None,
-            output_channel_indices=None,
+            input_channel_idx,
+            output_channel_idx,
             **func_args,
         )
     else:


### PR DESCRIPTION
This PR patches an the error in our function that parallelizes over t and c.

We haven't used this function in quite some time, but there were two bugs:
- Bug in the partial function that is launched to parallelize over T and C. 
- Previously we used to computed everything on zyx, so this function required an update to handle czyx 4D volumes in order for these to still work  (i.e `copy_n_paste_czyx`). 