### PR TITLE
move autotracker logs to /logs

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -25,7 +25,8 @@ authors:
     orcid: 'https://orcid.org/0000-0002-3033-674X'
   - given-names: 'Shalin B.'
     family-names: Mehta
-    affiliation: shalin.mehta@czbiohub.org
+    email: shalin.mehta@czbiohub.org
+    affiliation: Chan Zuckerberg Biohub San Francisco
     orcid: 'https://orcid.org/0000-0002-2542-3582'
 repository-code: 'https://github.com/czbiohub-sf/shrimPy'
 abstract: >-

--- a/mantis/acquisition/acq_engine.py
+++ b/mantis/acquisition/acq_engine.py
@@ -1130,12 +1130,12 @@ class MantisAcquisition(object):
         if self.lf_acq.microscope_settings.autotracker_config is not None:
             lf_image_saved_fn = partial(
                 autotracker_hook_fn,
-                'lf',
-                self.lf_acq.autotracker_settings,
-                self._position_settings,
-                self.lf_acq.microscope_settings.autotracker_config,
-                self.lf_acq.slice_settings,
-                self._acq_dir,
+                arm='lf',
+                autotracker_settings=self.lf_acq.autotracker_settings,
+                position_settings=self._position_settings,
+                channel_config=self.lf_acq.microscope_settings.autotracker_config,
+                z_slice_settings=self.lf_acq.slice_settings,
+                output_shift_path=self._logs_dir,
             )
         else:
             logger.info('No autotracker config found. Using default image saved hook')
@@ -1174,10 +1174,12 @@ class MantisAcquisition(object):
         if self.ls_acq.microscope_settings.autotracker_config is not None:
             ls_image_saved_fn = partial(
                 autotracker_hook_fn,
-                'ls',
-                self.ls_acq.autotracker_settings,
-                self.ls_acq.slice_settings,
-                self._acq_dir,
+                arm='ls',
+                autotracker_settings=self.ls_acq.autotracker_settings,
+                position_settings=self._position_settings,
+                channel_config=self.ls_acq.microscope_settings.autotracker_config,
+                z_slice_settings=self.ls_acq.slice_settings,
+                output_shift_path=self._logs_dir,
             )
         else:
             logger.info('No autotracker config found. Using default image saved hook')

--- a/mantis/acquisition/autotracker.py
+++ b/mantis/acquisition/autotracker.py
@@ -533,8 +533,8 @@ def autotracker_hook_fn(
                 # Reference and moving volumes
                 shifts_zyx = tracker.estimate_shift(volume_t0, volume_t1)
 
-            position_id = str(axes['position']) + '.csv'
-            shift_coord_output = output_shift_path / position_id
+            csv_log_filename = f"autotracker_fov_{axes['position']}.csv"
+            shift_coord_output = output_shift_path / csv_log_filename
 
             # Read the previous shifts_zyx and coords
             prev_shifts = pd.read_csv(shift_coord_output)
@@ -571,8 +571,8 @@ def autotracker_hook_fn(
             )
         else:
             # Save the positions at t=0
-            position_id = str(axes['position']) + '.csv'
-            shift_coord_output = output_shift_path / position_id
+            csv_log_filename = f"autotracker_fov_{axes['position']}.csv"
+            shift_coord_output = output_shift_path / csv_log_filename
             prev_y = position_settings.xyz_positions_shift[p_idx][1]
             prev_x = position_settings.xyz_positions_shift[p_idx][0]
             if position_settings.xyz_positions_shift[p_idx][2] is not None:

--- a/mantis/cli/main.py
+++ b/mantis/cli/main.py
@@ -1,6 +1,7 @@
 import click
 
 from mantis.cli.run_acquisition import run_acquisition
+from mantis.cli.stir_plate import stir_plate_cli
 
 CONTEXT = {"help_option_names": ["-h", "--help"]}
 
@@ -17,3 +18,4 @@ def cli():
 
 
 cli.add_command(run_acquisition)
+cli.add_command(stir_plate_cli)

--- a/mantis/cli/stir_plate.py
+++ b/mantis/cli/stir_plate.py
@@ -1,0 +1,78 @@
+import logging
+import time
+
+import click
+
+from pycromanager import Core, Studio
+
+from mantis.acquisition.acq_engine import LF_ZMQ_PORT
+from mantis.acquisition.microscope_operations import get_position_list, set_xy_position
+
+logger = logging.getLogger(__name__)
+
+
+def stir_plate(duration_hours: float, dwell_time_min: int) -> None:
+    """Move through all positions defined in the Micro-manager position list,
+    dwelling at each position for dwell_time_min until duration_hours is reached.
+    This helps distribute the silicone oil evenly across the plate.
+
+    Parameters
+    ----------
+    duration_hours : float
+        Total duration for stirring the plate in hours.
+    dwell_time_min : int
+        Time spent at each position in minutes.
+    """
+
+    # Connect to the Micro-manager Studio
+    mmc = Core(port=LF_ZMQ_PORT)
+    mmStudio = Studio(port=LF_ZMQ_PORT)
+    z_stage = None
+
+    # Import positions from the Micro-manager position list
+    positions, position_labels = get_position_list(mmStudio, z_stage)
+    num_positions = len(positions)
+    if num_positions == 0:
+        raise RuntimeError(
+            "No positions found in the Micro-manager position list. "
+            "Please create a position list before running this command."
+        )
+
+    p_idx = 0
+    t_start = time.time()
+    t_end = t_start + duration_hours * 3600  # Convert hours to seconds
+    while time.time() < t_end:
+        # Move to the next position
+        logger.info(f"Moving to position: {position_labels[p_idx]}")
+        set_xy_position(mmc, positions[p_idx][:2])
+
+        # Dwell for specified amount of time
+        time.sleep(dwell_time_min * 60)
+
+        # Increment position index, wrap around if necessary
+        p_idx = (p_idx + 1) % num_positions
+
+    # Move back to the first position
+    logger.info("Stirring completed, moving to the first position.")
+    set_xy_position(mmc, positions[0][:2])
+
+
+@click.command("stir-plate")
+@click.option(
+    "--duration-hours",
+    type=float,
+    required=True,
+    help="Total duration for stirring the plate in hours.",
+)
+@click.option(
+    "--dwell-time-min",
+    type=int,
+    required=False,
+    default=1,
+    help="Time spent at each position in minutes, by default 1 minute.",
+)
+def stir_plate_cli(duration_hours: float, dwell_time_min: int) -> None:
+    """Stir the plate by moving through all positions in the
+    Micro-manager position list.
+    """
+    stir_plate(duration_hours, dwell_time_min)


### PR DESCRIPTION
@tayllatheodoro I would like to move the autotracker logs to the `/logs` folder and call them `f"autotracker_fov_{axes['position']}.csv"`. Can you please review this PR? Can you confirm that I only need to change the `output_shift_path` in `autotracker_hook_fn`?