### PR TITLE
Migrate acquisition engine to pymmcore-plus

### DIFF
--- a/examples/acquisition_settings/demo_acquisition_settings.yaml
+++ b/examples/acquisition_settings/demo_acquisition_settings.yaml
@@ -53,6 +53,6 @@ ls_microscope_settings:
   device_property_settings:
     - ['Camera', 'OnCameraCCDXSize', '2048']
     - ['Camera', 'OnCameraCCDYSize', '2048']
-    - ['Camera', 'BitDepth', '11']
+    - ['Camera', 'BitDepth', '12']
   z_sequencing_settings:
     - ['Z', 'UseSequences', 'Yes']

--- a/examples/acquisition_settings/demo_acquisition_settings.yaml
+++ b/examples/acquisition_settings/demo_acquisition_settings.yaml
@@ -5,6 +5,16 @@ time_settings:
   num_timepoints: 3
   time_interval_s: 5
 
+position_settings:
+  xyz_positions:
+    - [0, 0, 0]
+    - [0, 0, 1]
+    - [0, 0, 2]
+  position_labels:
+    - 'One-Pos001'
+    - 'Two-Pos002'
+    - 'Three-Pos003'
+  
 lf_channel_settings:
   default_exposure_times_ms: [10, 10]
   channel_group: 'Channel-Multiband'

--- a/examples/acquisition_settings/example_acquisition_settings.yaml
+++ b/examples/acquisition_settings/example_acquisition_settings.yaml
@@ -38,6 +38,8 @@ lf_slice_settings:
   # steps in sample space. We can achieve this by using (300 nm)*1.4/2 = 210 nm
   # steps of the mirror due to the 1.4x magnification of the remote volume and the
   # fact that the optical path length is extended by twice the mirror's motion.
+  # The MCL Piezo stage is programmed to move in sample-space coordinates, i.e.
+  # (1 um)*1.4/2 = 0.7 um for every 1 um in sample space.
   #
   # Here we choose to oversample the data to match the light-sheet axial
   # sampling. After deskewing and 3x binning, the light-sheet samples are spaced

--- a/mantis/acquisition/acq_engine.py
+++ b/mantis/acquisition/acq_engine.py
@@ -58,8 +58,6 @@ from mantis.acquisition.hook_functions.image_saved_hook_functions import (
 
 
 # Define constants
-LF_ZMQ_PORT = 4827
-LS_ZMQ_PORT = 5827  # we need to space out port numbers a bit
 LS_POST_READOUT_DELAY = 0.05  # delay before acquiring next frame, in ms
 MCL_STEP_TIME = 1.5  # in ms
 LC_CHANGE_TIME = 20  # in ms
@@ -91,8 +89,6 @@ class BaseChannelSliceAcquisition(object):
         Path to Micro-manager which will be launched in headless mode, by default None
     mm_config_file : str, optional
         Path to config file for the headless acquisition, by default None
-    zmq_port : int, optional
-        ZeroMQ port of the acquisition, by default 4827
     core_log_path : str, optional
         Path where the headless acquisition core logs will be saved, by default ''
     """
@@ -102,7 +98,6 @@ class BaseChannelSliceAcquisition(object):
         enabled: bool = True,
         mm_app_path: str = None,
         mm_config_file: str = None,
-        zmq_port: int = 4827,
         core_log_path: str = '',
     ):
         self.enabled = enabled
@@ -134,8 +129,6 @@ class BaseChannelSliceAcquisition(object):
                     core_log_path=core_log_path,
                     buffer_size_mb=2048,
                 )
-
-            logger.debug(f'Connecting to Micro-Manager on port {zmq_port}')
 
             self.mmc = CMMCorePlus()
             self.mmc.loadSystemConfiguration(mm_config_file)
@@ -400,7 +393,6 @@ class MantisAcquisition(object):
         self.lf_acq = BaseChannelSliceAcquisition(
             enabled=enable_lf_acq,
             mm_config_file=mm_config_file,
-            zmq_port=LF_ZMQ_PORT,
         )
 
         # Connect to MM running LS acq
@@ -408,7 +400,6 @@ class MantisAcquisition(object):
             enabled=enable_ls_acq,
             mm_app_path=mm_app_path,
             mm_config_file=mm_config_file,
-            zmq_port=LS_ZMQ_PORT,
             core_log_path=Path(mm_app_path) / 'CoreLogs' / f'CoreLog{timestamp}_headless.txt',
         )
 

--- a/mantis/acquisition/acq_engine.py
+++ b/mantis/acquisition/acq_engine.py
@@ -136,8 +136,9 @@ class BaseChannelSliceAcquisition(object):
 
             logger.debug(f'Connecting to Micro-Manager on port {zmq_port}')
 
-            self.mmc = CMMCorePlus(mm_config_file) #Core(port=zmq_port)
-
+            self.mmc = CMMCorePlus()
+            self.mmc.loadSystemConfiguration(mm_config_file)
+            
             # headless MM instance doesn't have a studio object
             if not self.headless:
                 self.mmStudio = None #Studio(port=zmq_port)
@@ -398,6 +399,7 @@ class MantisAcquisition(object):
         # Connect to MM running LF acq
         self.lf_acq = BaseChannelSliceAcquisition(
             enabled=enable_lf_acq,
+            mm_config_file=mm_config_file,
             zmq_port=LF_ZMQ_PORT,
         )
 

--- a/mantis/acquisition/acq_engine.py
+++ b/mantis/acquisition/acq_engine.py
@@ -649,7 +649,10 @@ class MantisAcquisition(object):
             )
             return
 
-        if self.ls_acq.autoexposure_settings.autoexposure_method == 'manual':
+        if (
+            any(self.ls_acq.channel_settings.use_autoexposure)
+            and self.ls_acq.autoexposure_settings.autoexposure_method == 'manual'
+        ):
             # Check that the 'illumination.csv' file exists
             if not (self._root_dir / 'illumination.csv').exists():
                 raise FileNotFoundError(

--- a/mantis/acquisition/acq_engine.py
+++ b/mantis/acquisition/acq_engine.py
@@ -16,7 +16,9 @@ import numpy as np
 import tifffile
 
 from nidaqmx.constants import Slope
-from pycromanager import Acquisition, Core, Studio, multi_d_acquisition_events, start_headless
+#from pycromanager import Acquisition, Core, Studio, multi_d_acquisition_events, start_headless
+from pymmcore_plus import CMMCorePlus
+
 from waveorder.focus import focus_from_transverse_band
 
 from mantis import get_console_formatter
@@ -108,7 +110,7 @@ class BaseChannelSliceAcquisition(object):
         self._microscope_settings = MicroscopeSettings()
         self._autoexposure_settings = None
         self._z0 = None
-        self.headless = False if mm_app_path is None else True
+        self.headless = True #JGE False if mm_app_path is None else True
         self.type = 'light-sheet' if self.headless else 'label-free'
         self.mmc = None
         self.mmStudio = None
@@ -116,7 +118,7 @@ class BaseChannelSliceAcquisition(object):
 
         logger.debug(f'Initializing {self.type} acquisition engine')
         if enabled:
-            if self.headless:
+            if False: #JGE self.headless:
                 java_loc = None
                 if "JAVA_HOME" in os.environ:
                     java_loc = os.environ["JAVA_HOME"]
@@ -134,14 +136,14 @@ class BaseChannelSliceAcquisition(object):
 
             logger.debug(f'Connecting to Micro-Manager on port {zmq_port}')
 
-            self.mmc = Core(port=zmq_port)
+            self.mmc = CMMCorePlus() #Core(port=zmq_port)
 
             # headless MM instance doesn't have a studio object
             if not self.headless:
-                self.mmStudio = Studio(port=zmq_port)
+                self.mmStudio = None #Studio(port=zmq_port)
 
             logger.debug('Successfully connected to Micro-Manager')
-            logger.debug(f'{self.mmc.get_version_info()}')  # MMCore Version
+            logger.debug(f'{self.mmc.getVersionInfo()}')  # MMCore Version
 
             if not self.headless:
                 logger.debug(f'MM Studio version: {self.mmStudio.compat().get_version()}')

--- a/mantis/acquisition/acq_engine.py
+++ b/mantis/acquisition/acq_engine.py
@@ -1109,7 +1109,7 @@ class MantisAcquisition(object):
         # )
 
         self._lf_acq_obj = OMETiffWriter(
-            filename=self._acq_dir / f'{self._acq_name}_{LF_ACQ_LABEL}.tif'
+            filename=self._acq_dir / f'{self._acq_name}_{LF_ACQ_LABEL}.ome.tif'
         )
         # define LS hook functions
         if self._demo_run:
@@ -1142,8 +1142,8 @@ class MantisAcquisition(object):
         #     saving_queue_size=500,
         #     show_display=False,
         # )
-        self._lf_acq_obj = OMETiffWriter(
-            filename=self._acq_dir / f'{self._acq_name}_{LS_ACQ_LABEL}.tif'
+        self._ls_acq_obj = OMETiffWriter(
+            filename=self._acq_dir / f'{self._acq_name}_{LS_ACQ_LABEL}.ome.tif'
         )
 
         # Generate LF acquisition events

--- a/mantis/acquisition/acq_engine.py
+++ b/mantis/acquisition/acq_engine.py
@@ -1243,7 +1243,7 @@ class MantisAcquisition(object):
 
                 # since MDAEvents can't be modified in place, we need to recreate the whole mda_sequence
                 # and explicitly set the index for each event
-                def tweek_event(event):
+                def mda_event_from_mda_sequence(event):
 
                     # new autoexposure, if any
                     new_exposure = event.exposure
@@ -1267,8 +1267,8 @@ class MantisAcquisition(object):
                         reset_event_timer=event.reset_event_timer
                     )
 
-                lf_events = [tweek_event(event) for event in lf_cz_events] 
-                ls_events = [tweek_event(event) for event in ls_cz_events]
+                lf_events = [mda_event_from_mda_sequence(event) for event in lf_cz_events] 
+                ls_events = [mda_event_from_mda_sequence(event) for event in ls_cz_events]
 
                 # globals.lf_last_img_idx = lf_events[-1]['axes']
                 # globals.ls_last_img_idx = ls_events[-1]['axes']

--- a/mantis/acquisition/acq_engine.py
+++ b/mantis/acquisition/acq_engine.py
@@ -773,7 +773,7 @@ class MantisAcquisition(object):
 
         Parameters
         ----------
-        mmc : Core
+        mmc : CMMCorePlus
         mmStudio : Studio
         z_stage : str or KinesisPiezoMotor
         z_range : Iterable

--- a/mantis/acquisition/acq_engine.py
+++ b/mantis/acquisition/acq_engine.py
@@ -16,8 +16,8 @@ import numpy as np
 import tifffile
 
 from nidaqmx.constants import Slope
-#from pycromanager import Acquisition, Core, Studio, multi_d_acquisition_events, start_headless
 from pymmcore_plus import CMMCorePlus
+from pymmcore_plus.mda.handlers import OMETiffWriter
 import useq
 
 from waveorder.focus import focus_from_transverse_band
@@ -1108,6 +1108,9 @@ class MantisAcquisition(object):
         #     show_display=False,
         # )
 
+        self._lf_acq_obj = OMETiffWriter(
+            filename=self._acq_dir / f'{self._acq_name}_{LF_ACQ_LABEL}.tif'
+        )
         # define LS hook functions
         if self._demo_run:
             ls_pre_hardware_hook_fn = None
@@ -1139,6 +1142,9 @@ class MantisAcquisition(object):
         #     saving_queue_size=500,
         #     show_display=False,
         # )
+        self._lf_acq_obj = OMETiffWriter(
+            filename=self._acq_dir / f'{self._acq_name}_{LS_ACQ_LABEL}.tif'
+        )
 
         # Generate LF acquisition events
         lf_cz_events = _generate_channel_slice_mda_seq(
@@ -1266,8 +1272,8 @@ class MantisAcquisition(object):
                 globals.ls_acq_aborted = False
 
                 # start acquisition
-                ls_thread = self.ls_acq.mmc.run_mda(ls_events)
-                lf_thread = self.lf_acq.mmc.run_mda(lf_events)
+                ls_thread = self.ls_acq.mmc.run_mda(ls_events, output=self._ls_acq_obj)
+                lf_thread = self.lf_acq.mmc.run_mda(lf_events, output=self._lf_acq_obj)
 
                 # wait for CZYX acquisition to finish
                 self.await_cz_acq_completion()

--- a/mantis/acquisition/microscope_operations.py
+++ b/mantis/acquisition/microscope_operations.py
@@ -63,16 +63,16 @@ def set_config(mmc, config_group, config_name):
 def set_property(mmc, device_name, property_name, property_value):
     logger.debug(f'Setting {device_name} {property_name} to {property_value}')
 
-    mmc.set_property(device_name, property_name, property_value)
+    mmc.setProperty(device_name, property_name, property_value)
 
     if 'Line Selector' in property_name:
-        mmc.update_system_state_cache()
+        mmc.updateSystemStateCache()
 
 
 def set_roi(mmc, roi: tuple):
     logger.debug(f'Setting ROI to {roi}')
 
-    mmc.set_roi(*roi)
+    mmc.setROI(*roi)
 
 
 def get_position_list(mmStudio, z_stage_name):
@@ -98,9 +98,9 @@ def get_position_list(mmStudio, z_stage_name):
 def get_current_position(mmc, z_stage_name):
     xyz_position = [
         (
-            mmc.get_x_position(),
-            mmc.get_y_position(),
-            mmc.get_position(z_stage_name) if z_stage_name else None,
+            mmc.getXPosition(),
+            mmc.getYPosition(),
+            mmc.getPosition(z_stage_name) if z_stage_name else None,
         )
     ]
     position_label = ['FOV0']
@@ -222,10 +222,10 @@ def autofocus(mmc, mmStudio, z_stage_name: str, z_position):
         logger.debug('Continuous autofocus is already engaged')
     else:
         for z_offset in z_offsets:
-            mmc.set_position(z_stage_name, z_position + z_offset)
-            mmc.wait_for_device(z_stage_name)
+            mmc.setPosition(z_stage_name, z_position + z_offset)
+            mmc.waitForDevice(z_stage_name)
 
-            af_method.enable_continuous_focus(True)  # this call engages autofocus
+            af_method.enableContinuousFocus(True)  # this call engages autofocus
             time.sleep(1)  # wait an extra second
 
             if af_method.is_continuous_focus_locked():
@@ -367,7 +367,7 @@ def acquire_defocus_stack(
     # get z0 and define move_z callable for the given stage
     if isinstance(z_stage, str):
         # this is a MM stage
-        move_z = partial(mmc.set_relative_position, z_stage)  # test if this works
+        move_z = partial(mmc.setRelativePosition, z_stage)  # test if this works
     elif isinstance(z_stage, KinesisPiezoMotor):
         # this is a pylablib stage
         move_z = partial(set_relative_kim101_position, z_stage)
@@ -379,8 +379,8 @@ def acquire_defocus_stack(
         move_z(rel_z)
 
         # snap image
-        mmc.snap_image()
-        tagged_image = mmc.get_tagged_image()
+        mmc.snapImage()
+        tagged_image = mmc.getTaggedImage()
 
         # get image data
         image_data = np.reshape(
@@ -443,20 +443,20 @@ def acquire_ls_defocus_stack_and_display(
 
     # Set config
     if config_name is not None:
-        mmc.set_config(config_group, config_name)
-        mmc.wait_for_config(config_group, config_name)
+        mmc.setConfig(config_group, config_name)
+        mmc.waitForConfig(config_group, config_name)
 
     # Open shutter
     auto_shutter_state, shutter_state = get_shutter_state(mmc)
     open_shutter(mmc)
 
     # get galvo starting position
-    p0 = mmc.get_position(galvo)
+    p0 = mmc.getPosition(galvo)
 
     # acquire stack at different galvo positions
     for p_idx, p in enumerate(galvo_range):
         # set galvo position
-        mmc.set_position(galvo, p0 + p)
+        mmc.setPosition(galvo, p0 + p)
 
         # acquire defocus stack
         z_stack = acquire_defocus_stack(
@@ -468,7 +468,7 @@ def acquire_ls_defocus_stack_and_display(
     datastore.freeze()
 
     # Reset galvo
-    mmc.set_position(galvo, p0)
+    mmc.setPosition(galvo, p0)
 
     # Reset shutter
     reset_shutter(mmc, auto_shutter_state, shutter_state)
@@ -494,8 +494,8 @@ def get_shutter_state(mmc: CMMCorePlus):
     shutter_state : bool
 
     """
-    auto_shutter_state = mmc.get_auto_shutter()
-    shutter_state = mmc.get_shutter_open()
+    auto_shutter_state = mmc.getAutoShutter()
+    shutter_state = mmc.getShutterOpen()
 
     return auto_shutter_state, shutter_state
 
@@ -509,11 +509,11 @@ def open_shutter(mmc: CMMCorePlus):
 
     """
 
-    shutter_device = mmc.get_shutter_device()
+    shutter_device = mmc.getShutterDevice()
     if shutter_device:
         logger.debug(f'Opening shutter {shutter_device}')
-        mmc.set_auto_shutter(False)
-        mmc.set_shutter_open(True)
+        mmc.setAutoShutter(False)
+        mmc.setShutterOpen(True)
 
 
 def reset_shutter(mmc: CMMCorePlus, auto_shutter_state: bool, shutter_state: bool):
@@ -527,7 +527,7 @@ def reset_shutter(mmc: CMMCorePlus, auto_shutter_state: bool, shutter_state: boo
 
     """
 
-    shutter_device = mmc.get_shutter_device()
+    shutter_device = mmc.getShutterDevice()
     if shutter_device:
         logger.debug(
             'Resetting shutter %s to state Open:%s, Autoshutter: %s',
@@ -535,8 +535,8 @@ def reset_shutter(mmc: CMMCorePlus, auto_shutter_state: bool, shutter_state: boo
             shutter_state,
             auto_shutter_state,
         )
-        mmc.set_shutter_open(shutter_state)
-        mmc.set_auto_shutter(auto_shutter_state)
+        mmc.setShutterOpen(shutter_state)
+        mmc.setAutoShutter(auto_shutter_state)
 
 
 def abort_acquisition_sequence(
@@ -554,9 +554,9 @@ def abort_acquisition_sequence(
     """
 
     for stage in sequenced_stages:
-        mmc.stop_stage_sequence(stage)
-    mmc.stop_sequence_acquisition(camera)
-    mmc.clear_circular_buffer()
+        mmc.stopStageSequence(stage)
+    mmc.stopSequenceAcquisition(camera)
+    mmc.clearCircularBuffer()
 
 
 def setup_vortran_laser(com_port: str):
@@ -581,7 +581,7 @@ def setup_vortran_laser(com_port: str):
 def set_exposure(mmc: CMMCorePlus, exposure_time: float):
     logger.debug(f'Setting exposure time to {exposure_time:.2f} ms')
 
-    mmc.set_exposure(exposure_time)
+    mmc.setExposure(exposure_time)
 
 
 def autoexposure(
@@ -614,7 +614,7 @@ def autoexposure(
     """
 
     autoexposure_flag = None
-    current_exposure_time = mmc.get_exposure()
+    current_exposure_time = mmc.getExposure()
     current_light_intensity = None
     if isinstance(light_source, VortranLaser):
         current_light_intensity = light_source.pulse_power

--- a/mantis/acquisition/microscope_operations.py
+++ b/mantis/acquisition/microscope_operations.py
@@ -341,7 +341,7 @@ def acquire_defocus_stack(
 
     Parameters
     ----------
-    mmc : Core
+    mmc : CMMCorePlus
     z_stage : str or coPylot stage object
     z_range : Iterable
     mmStudio : Studio, optional
@@ -423,7 +423,7 @@ def acquire_ls_defocus_stack_and_display(
 
     Parameters
     ----------
-    mmc : Core
+    mmc : CMMCorePlus
     mmStudio : Studio
     z_stage : str or KinesisPiezoMotor
     z_range : Iterable
@@ -486,7 +486,7 @@ def get_shutter_state(mmc: CMMCorePlus):
 
     Parameters
     ----------
-    mmc : Core
+    mmc : CMMCorePlus
 
     Returns
     -------
@@ -505,7 +505,7 @@ def open_shutter(mmc: CMMCorePlus):
 
     Parameters
     ----------
-    mmc : Core
+    mmc : CMMCorePlus
 
     """
 
@@ -521,7 +521,7 @@ def reset_shutter(mmc: CMMCorePlus, auto_shutter_state: bool, shutter_state: boo
 
     Parameters
     ----------
-    mmc : Core
+    mmc : CMMCorePlus
     auto_shutter_state : bool
     shutter_state : bool
 
@@ -546,7 +546,7 @@ def abort_acquisition_sequence(
 
     Parameters
     ----------
-    mmc : Core
+    mmc : CMMCorePlus
     camera : str, optional
         Camera name, by default None
     sequenced_stages : Iterable[str], optional
@@ -603,7 +603,7 @@ def autoexposure(
 
     Parameters
     ----------
-    mmc : Core light_source : Union[str, VortranLaser]
+    mmc : CMMCorePlus light_source : Union[str, VortranLaser]
         Light source name for sources controlled by Micro-manager or
         VortranLaser object
     autoexposure_settings : AutoexposureSettings autoexposure_method : str

--- a/mantis/acquisition/microscope_operations.py
+++ b/mantis/acquisition/microscope_operations.py
@@ -9,7 +9,8 @@ import numpy as np
 
 from copylot.hardware.lasers.vortran.vortran import VortranLaser
 from nidaqmx.constants import AcquisitionType
-from pycromanager import Core, Studio
+#from pycromanager import Core, Studio
+from pymmcore_plus import CMMCorePlus
 from pylablib.devices.Thorlabs import KinesisPiezoMotor
 
 from mantis.acquisition.AcquisitionSettings import AutoexposureSettings
@@ -56,7 +57,7 @@ def _try_mmc_call(mmc, mmc_call_name, *mmc_carr_args):
 def set_config(mmc, config_group, config_name):
     logger.debug(f'Setting {config_group} config group to {config_name}')
 
-    mmc.set_config(config_group, config_name)
+    mmc.setConfig(config_group, config_name)
 
 
 def set_property(mmc, device_name, property_name, property_value):
@@ -307,7 +308,7 @@ def set_relative_kim101_position(
 
 
 def create_ram_datastore(
-    mmStudio: Studio,
+    mmStudio = None,
 ):
     """Create a Micro-manager RAM datastore and associate a display window with it
 
@@ -327,10 +328,10 @@ def create_ram_datastore(
 
 
 def acquire_defocus_stack(
-    mmc: Core,
+    mmc: CMMCorePlus,
     z_stage: Union[str, KinesisPiezoMotor],
     z_range: Iterable,
-    mmStudio: Studio = None,
+    mmStudio = None,
     datastore=None,
     channel_ind: int = 0,
     position_ind: int = 0,
@@ -406,12 +407,12 @@ def acquire_defocus_stack(
 
 
 def acquire_ls_defocus_stack_and_display(
-    mmc: Core,
-    mmStudio: Studio,
+    mmc: CMMCorePlus,
     z_stage: Union[str, KinesisPiezoMotor],
     z_range: Iterable,
     galvo: str,
     galvo_range: Iterable,
+    mmStudio = None,
     config_group: str = None,
     config_name: str = None,
     close_display: bool = True,
@@ -480,7 +481,7 @@ def acquire_ls_defocus_stack_and_display(
     return np.asarray(data)
 
 
-def get_shutter_state(mmc: Core):
+def get_shutter_state(mmc: CMMCorePlus):
     """Return the current state of the shutter
 
     Parameters
@@ -499,7 +500,7 @@ def get_shutter_state(mmc: Core):
     return auto_shutter_state, shutter_state
 
 
-def open_shutter(mmc: Core):
+def open_shutter(mmc: CMMCorePlus):
     """Open shutter if mechanical shutter exists
 
     Parameters
@@ -515,7 +516,7 @@ def open_shutter(mmc: Core):
         mmc.set_shutter_open(True)
 
 
-def reset_shutter(mmc: Core, auto_shutter_state: bool, shutter_state: bool):
+def reset_shutter(mmc: CMMCorePlus, auto_shutter_state: bool, shutter_state: bool):
     """Reset shutter if mechanical shutter exists
 
     Parameters
@@ -539,7 +540,7 @@ def reset_shutter(mmc: Core, auto_shutter_state: bool, shutter_state: bool):
 
 
 def abort_acquisition_sequence(
-    mmc: Core, camera: str = None, sequenced_stages: Iterable[str] = []
+    mmc: CMMCorePlus, camera: str = None, sequenced_stages: Iterable[str] = []
 ):
     """Abort acquisition sequence and clear circular buffer
 
@@ -577,14 +578,14 @@ def setup_vortran_laser(com_port: str):
     return laser
 
 
-def set_exposure(mmc: Core, exposure_time: float):
+def set_exposure(mmc: CMMCorePlus, exposure_time: float):
     logger.debug(f'Setting exposure time to {exposure_time:.2f} ms')
 
     mmc.set_exposure(exposure_time)
 
 
 def autoexposure(
-    mmc: Core,
+    mmc: CMMCorePlus,
     light_source: Union[str, VortranLaser],
     autoexposure_settings: AutoexposureSettings,
     autoexposure_method: str = None,

--- a/mantis/acquisition/microscope_operations.py
+++ b/mantis/acquisition/microscope_operations.py
@@ -109,25 +109,25 @@ def get_current_position(mmc, z_stage_name):
 
 
 def set_z_position(mmc, z_stage_name: str, z_position: float):
-    _try_mmc_call(mmc, 'set_position', str(z_stage_name), float(z_position))
+    _try_mmc_call(mmc, 'setPosition', str(z_stage_name), float(z_position))
 
 
 def set_relative_z_position(mmc, z_stage_name: str, z_offset: float):
-    _try_mmc_call(mmc, 'set_relative_position', str(z_stage_name), float(z_offset))
+    _try_mmc_call(mmc, 'setRelativePosition', str(z_stage_name), float(z_offset))
 
 
 def set_xy_position(mmc, xy_position: Tuple[float, float]):
-    _try_mmc_call(mmc, 'set_xy_position', float(xy_position[0]), float(xy_position[1]))
+    _try_mmc_call(mmc, 'setXYPosition', float(xy_position[0]), float(xy_position[1]))
 
 
 def set_relative_xy_position(mmc, xy_offset: Tuple[float, float]):
-    _try_mmc_call(mmc, 'set_relative_xy_position', float(xy_offset[0]), float(xy_offset[1]))
+    _try_mmc_call(mmc, 'setRelativeXYPosition', float(xy_offset[0]), float(xy_offset[1]))
 
 
 def wait_for_device(mmc, device_name: str):
     _try_mmc_call(
         mmc,
-        'wait_for_device',
+        'waitForDevice',
         str(device_name),
     )
 

--- a/mantis/cli/run_acquisition.py
+++ b/mantis/cli/run_acquisition.py
@@ -63,8 +63,7 @@ def run_acquisition(
     )
 
     # isort: on
-
-    demo_run = True if 'demo' in mm_config_filepath else False
+    demo_run = 'demo' in mm_config_filepath.lower()
 
     output_dirpath = Path(output_dirpath)
     acq_directory, acq_name = output_dirpath.parent, output_dirpath.name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
   "nidaqmx",
   "numpy<2",
   "pycromanager==0.28.1",
+  "pymmcore_plus==0.13.6",
   "pydantic>=2.0.0",
   "pylablib==1.4.1",
   "tifffile",


### PR DESCRIPTION
This PR addresses #170 .

This is a copy of #171, but we've moved the development branch into this repository rather than a fork in the acquire-project.

Since migrating the acquisition engine is largely an all-or-nothing endeavor, this PR tracks the entire project's progress: whereas individual features will be merged into this branch with their own PRs. 