### PR TITLE
Autoexposure safety checks

### DIFF
--- a/mantis/acquisition/AcquisitionSettings.py
+++ b/mantis/acquisition/AcquisitionSettings.py
@@ -73,6 +73,7 @@ class ChannelSettings:
     # dictionaries with following structure: {well_id: list_of_exposure_times}
     exposure_times_per_well: Dict = field(init=None, default_factory=dict)
     laser_powers_per_well: Dict = field(init=None, default_factory=dict)
+    min_exposure_time: NonNegativeFloat = 0  # in ms
 
     def __post_init__(self):
         self.num_channels = len(self.channels)

--- a/mantis/acquisition/acq_engine.py
+++ b/mantis/acquisition/acq_engine.py
@@ -20,8 +20,8 @@ from pycromanager import Acquisition, Core, Studio, multi_d_acquisition_events, 
 from waveorder.focus import focus_from_transverse_band
 
 from mantis import get_console_formatter
-from mantis.acquisition.autoexposure import load_manual_illumination_settings
 from mantis.acquisition import microscope_operations
+from mantis.acquisition.autoexposure import load_manual_illumination_settings
 from mantis.acquisition.hook_functions import globals
 from mantis.acquisition.logger import configure_debug_logger, log_conda_environment
 
@@ -673,7 +673,7 @@ class MantisAcquisition(object):
                 'Autoexposure is not supported in demo mode. Using default exposure time and laser power'
             )
             return
-    
+
         if self.ls_acq.autoexposure_settings.autoexposure_method is None:
             raise ValueError(
                 'Autoexposure is requested, but autoexposure settings are not provided. '
@@ -691,12 +691,17 @@ class MantisAcquisition(object):
                 self._root_dir / 'illumination.csv',
             )
             # Check that exposure times are greater than the minimum exposure time
-            if not (illumination_settings["exposure_time_ms"] > self.ls_acq.channel_settings.min_exposure_time).all():
+            if not (
+                illumination_settings["exposure_time_ms"]
+                > self.ls_acq.channel_settings.min_exposure_time
+            ).all():
                 raise ValueError(
                     f'All exposure times in the illumination.csv file must be greater than the minimum exposure time of {self.ls_acq.channel_settings.min_exposure_time} ms.'
                 )
             # Check that illumination settings are provided for all wells
-            if not set(illumination_settings.index.values) == set(self.position_settings.well_ids):
+            if not set(illumination_settings.index.values) == set(
+                self.position_settings.well_ids
+            ):
                 raise ValueError(
                     'Well IDs in the illumination.csv file do not match the well IDs in the position settings.'
                 )

--- a/mantis/acquisition/acq_engine.py
+++ b/mantis/acquisition/acq_engine.py
@@ -661,12 +661,6 @@ class MantisAcquisition(object):
                 self.ls_acq.channel_settings.default_laser_powers
             )
 
-        if self._demo_run:
-            logger.debug(
-                'Autoexposure is not supported in demo mode. Using default exposure time and laser power'
-            )
-            return
-
         if (
             any(self.ls_acq.channel_settings.use_autoexposure)
             and self.ls_acq.autoexposure_settings.autoexposure_method == 'manual'
@@ -683,6 +677,12 @@ class MantisAcquisition(object):
                 raise ValueError(
                     f'All exposure times in the illumination.csv file must be greater than the minimum exposure time of {self.ls_acq.channel_settings.min_exposure_time} ms.'
                 )
+            
+        if self._demo_run:
+            logger.debug(
+                'Autoexposure is not supported in demo mode. Using default exposure time and laser power'
+            )
+            return
 
         # initialize lasers
         for channel_idx, config_name in enumerate(self.ls_acq.channel_settings.channels):

--- a/mantis/acquisition/autoexposure.py
+++ b/mantis/acquisition/autoexposure.py
@@ -39,6 +39,7 @@ def load_manual_illumination_settings(csv_filepath: str) -> pd.DataFrame:
 
     return df
 
+
 def manual_autoexposure(
     current_exposure_time,
     current_laser_power,

--- a/mantis/acquisition/autoexposure.py
+++ b/mantis/acquisition/autoexposure.py
@@ -28,7 +28,7 @@ def load_manual_illumination_settings(csv_filepath: str) -> pd.DataFrame:
     - laser_power_mW
     """
 
-    df = pd.read_csv(csv_filepath)
+    df = pd.read_csv(csv_filepath, dtype=str)
     if not set(df.columns) == {"well_id", "exposure_time_ms", "laser_power_mW"}:
         raise ValueError(
             "CSV file must contain columns: well_id, exposure_time_ms, laser_power_mW"

--- a/mantis/acquisition/autoexposure.py
+++ b/mantis/acquisition/autoexposure.py
@@ -12,13 +12,32 @@
 # adjusting camera exposure and laser power based on these suggestions until
 # convergence.
 
-import csv
-
 import numpy as np
+import pandas as pd
 
 from mantis import logger
 from mantis.acquisition.AcquisitionSettings import AutoexposureSettings
 
+
+def load_manual_illumination_settings(csv_filepath: str) -> pd.DataFrame:
+    """
+    Import the manual illumination settings from a CSV file.
+    The CSV file should have the following columns:
+    - well_id
+    - exposure_time_ms
+    - laser_power_mW
+    """
+
+    df = pd.read_csv(csv_filepath)
+    if not set(df.columns) == {"well_id", "exposure_time_ms", "laser_power_mW"}:
+        raise ValueError(
+            "CSV file must contain columns: well_id, exposure_time_ms, laser_power_mW"
+        )
+    df.set_index("well_id", inplace=True)
+    df["exposure_time_ms"] = df["exposure_time_ms"].astype(float)
+    df["laser_power_mW"] = df["laser_power_mW"].astype(float)
+
+    return df
 
 def manual_autoexposure(
     current_exposure_time,
@@ -26,20 +45,20 @@ def manual_autoexposure(
     illumination_settings_filepath,
     well_id,
 ):
-    autoexposure_flag = (
-        None  # 1: over-exposed , 0: optimally exposed, -1: under-exposed, None: error
-    )
-    suggested_exposure_time = current_exposure_time
-    suggested_laser_power = current_laser_power
-    with open(illumination_settings_filepath) as csvfile:
-        reader = csv.reader(csvfile)
-
-        for line in reader:
-            if line[0] == well_id:
-                autoexposure_flag = 0
-                suggested_exposure_time = float(line[1])
-                suggested_laser_power = float(line[2])
-                break
+    try:
+        autoexposure_flag = 0
+        illumination_settings = load_manual_illumination_settings(
+            illumination_settings_filepath
+        )
+        suggested_exposure_time = illumination_settings.loc[well_id, "exposure_time_ms"]
+        suggested_laser_power = illumination_settings.loc[well_id, "laser_power_mW"]
+    except Exception as e:
+        logger.error(f"Error reading manual illumination settings: {e}")
+        # If autoexposure fails, we return None for autoexposure_flag
+        # and keep the current exposure time and laser power
+        autoexposure_flag = None
+        suggested_exposure_time = current_exposure_time
+        suggested_laser_power = current_laser_power
 
     return autoexposure_flag, suggested_exposure_time, suggested_laser_power
 


### PR DESCRIPTION
This PR adds safety checks when doing manual autoexposure
 * Load csv file as pandas dataframe and check that it has the correct columns
 * Check that the requested exposure time is below the minimal for the camera/acquisition
 * Check that illumination settings are provided for all wells in the MM position list