### PR TITLE
Update MM position list when using autotracker

### DIFF
--- a/mantis/acquisition/acq_engine.py
+++ b/mantis/acquisition/acq_engine.py
@@ -1425,6 +1425,9 @@ class MantisAcquisition(object):
         logger.info('Acquisition finished')
 
         if use_autotracker:
+            # update self.position_settings with the latest autotracker positions
+            self.update_position_autotracker()
+            # update mm position list
             self.update_mm_position_list()
 
     def await_cz_acq_completion(self):

--- a/mantis/acquisition/acq_engine.py
+++ b/mantis/acquisition/acq_engine.py
@@ -1179,15 +1179,15 @@ class MantisAcquisition(object):
         if self.lf_acq.microscope_settings.autotracker_config is not None:
             lf_image_saved_fn = partial(
                 autotracker_hook_fn,
-                arm='lf',
-                autotracker_settings=self.lf_acq.autotracker_settings,
-                position_settings=self._position_settings,
-                channel_config=self.lf_acq.microscope_settings.autotracker_config,
-                z_slice_settings=self.lf_acq.slice_settings,
-                output_shift_path=self._logs_dir,
+                'lf',
+                self.lf_acq.autotracker_settings,
+                self._position_settings,
+                self.lf_acq.microscope_settings.autotracker_config,
+                self.lf_acq.slice_settings,
+                self._logs_dir,
             )
         else:
-            logger.info('No autotracker config found. Using default image saved hook')
+            logger.info('No autotracker config found for LF acquisition. Using default image saved hook')
             lf_image_saved_fn = check_lf_acq_finished
 
         # define LF acquisition
@@ -1223,15 +1223,15 @@ class MantisAcquisition(object):
         if self.ls_acq.microscope_settings.autotracker_config is not None:
             ls_image_saved_fn = partial(
                 autotracker_hook_fn,
-                arm='ls',
-                autotracker_settings=self.ls_acq.autotracker_settings,
-                position_settings=self._position_settings,
-                channel_config=self.ls_acq.microscope_settings.autotracker_config,
-                z_slice_settings=self.ls_acq.slice_settings,
-                output_shift_path=self._logs_dir,
+                'ls',
+                self.ls_acq.autotracker_settings,
+                self._position_settings,
+                self.ls_acq.microscope_settings.autotracker_config,
+                self.ls_acq.slice_settings,
+                self._logs_dir,
             )
         else:
-            logger.info('No autotracker config found. Using default image saved hook')
+            logger.info('No autotracker config found for LS acquisition. Using default image saved hook')
             ls_image_saved_fn = check_ls_acq_finished
 
         # define LS acquisition
@@ -1425,7 +1425,7 @@ class MantisAcquisition(object):
         logger.info('Acquisition finished')
 
         if use_autotracker:
-            self.update_mm_position_settings()
+            self.update_mm_position_list()
 
     def await_cz_acq_completion(self):
         # LS acq time

--- a/mantis/acquisition/microscope_operations.py
+++ b/mantis/acquisition/microscope_operations.py
@@ -9,8 +9,7 @@ import numpy as np
 
 from copylot.hardware.lasers.vortran.vortran import VortranLaser
 from nidaqmx.constants import AcquisitionType
-import pycromanager
-from pycromanager import Core, Studio
+from pycromanager import Core, JavaObject, Studio
 from pylablib.devices.Thorlabs import KinesisPiezoMotor
 
 from mantis.acquisition.AcquisitionSettings import AutoexposureSettings, AutotrackerSettings
@@ -120,7 +119,7 @@ def update_position_list(
         try:
             # Update the position with a matching label
             idx = position_labels.index(mm_pos_label)
-            mm_position = pycromanager.JavaObject(
+            mm_position = JavaObject(
                 "org.micromanager.MultiStagePosition",
                 [
                     xy_stage_name,


### PR DESCRIPTION
This PR updates the MM position list at the end of mantis acquisitions when using autotracker such that the next acquisition can start where the previous one left off