### PR TITLE
DynaTrack: image-to-stage transform matrix + correct shift direction

### DIFF
--- a/config/mda/mantis/dynatrack_demo.yaml
+++ b/config/mda/mantis/dynatrack_demo.yaml
@@ -83,6 +83,10 @@ metadata:
           scan_step_um: 0.15
           keep_overhang: false
           average_n_slices: 3
+          image_to_stage_matrix_xyz: 
+            - [0.0, 1.0, 0.0]
+            - [1.0, 0.0, 0.0]
+            - [0.0, 0.0, 1.0]
         # Which channel to use for shift estimation:
         # 'raw', 'phase', 'vs_nuclei', 'vs_membrane'
         shift_estimation_channel: 'vs_nuclei'

--- a/config/mda/mantis/dynatrack_demo.yaml
+++ b/config/mda/mantis/dynatrack_demo.yaml
@@ -77,16 +77,16 @@ metadata:
         # preprocessing: ['phase']
 
         # Biahub deskew parameters for light-sheet data
+        image_to_stage_matrix_xyz:
+          - [0.0, 1.0, 0.0]
+          - [1.0, 0.0, 0.0]
+          - [0.0, 0.0, 1.0]
         deskew_config:
           ls_angle_deg: 30.0
           pixel_size_um: 0.1133
           scan_step_um: 0.15
           keep_overhang: false
           average_n_slices: 3
-          image_to_stage_matrix_xyz: 
-            - [0.0, 1.0, 0.0]
-            - [1.0, 0.0, 0.0]
-            - [0.0, 0.0, 1.0]
         # Which channel to use for shift estimation:
         # 'raw', 'phase', 'vs_nuclei', 'vs_membrane'
         shift_estimation_channel: 'vs_nuclei'

--- a/config/mda/mantis/dynatrack_demo.yaml
+++ b/config/mda/mantis/dynatrack_demo.yaml
@@ -77,9 +77,13 @@ metadata:
         # preprocessing: ['phase']
 
         # Biahub deskew parameters for light-sheet data
+        # Proper 90-deg rotation (det +1) mapping deskewed-image axes to stage
+        # axes; image-X is inverted relative to stage-Y. Validated on-microscope:
+        # both in-plane axes converge to the deadband (a pure swap, det -1, drove
+        # one axis to diverge). Setup-specific -- recalibrate per scope orientation.
         image_to_stage_matrix_xyz:
           - [0.0, 1.0, 0.0]
-          - [1.0, 0.0, 0.0]
+          - [-1.0, 0.0, 0.0]
           - [0.0, 0.0, 1.0]
         deskew_config:
           ls_angle_deg: 30.0

--- a/shrimpy/mantis/dynatrack.py
+++ b/shrimpy/mantis/dynatrack.py
@@ -369,7 +369,7 @@ class DynaTrackUpdater(PositionUpdater):
     ) -> None:
         self._config = config
         self._preprocessor = preprocessor
-        self._reference_stacks: dict[int, torch.Tensor] = {}
+        self._reference_stacks_zyx: dict[int, torch.Tensor] = {}
         self._shift_log_path: Path | None = (
             Path(config.shift_log_path) if config.shift_log_path else None
         )
@@ -446,45 +446,46 @@ class DynaTrackUpdater(PositionUpdater):
         # the PCC/saving boundaries below.
         if self._preprocessor is not None:
             t0 = _time.monotonic()
-            channels = self._preprocessor(raw_stack)
+            channels_zyx = self._preprocessor(raw_stack)
             logger.info(
                 f"DynaTrack: preprocessing took {_time.monotonic() - t0:.1f}s "
-                f"(channels={list(channels.keys())})"
+                f"(channels={list(channels_zyx.keys())})"
             )
-            ch_bytes = sum(a.nbytes for a in channels.values())
+            ch_bytes = sum(a.nbytes for a in channels_zyx.values())
             logger.debug(
                 f"DynaTrack[mem]: after preprocessor p={position_index} t={timepoint_index} "
                 f"rss={_rss_gb():.2f} GB channels_total={ch_bytes / 1024**3:.2f} GB"
             )
-            self._save_debug_channels(channels, timepoint_index, position_index)
+            self._save_debug_channels(channels_zyx, timepoint_index, position_index)
             # Select the configured channel for shift estimation. Stays as a
             # torch tensor on device; PCC consumes tensors directly.
             channel_name = self._config.shift_estimation_channel
-            if channel_name in channels:
-                selected = channels[channel_name]
+            if channel_name in channels_zyx:
+                selected = channels_zyx[channel_name]
             else:
                 logger.warning(
                     f"DynaTrack: channel '{channel_name}' not in preprocessor "
-                    f"output {list(channels.keys())}, using first channel"
+                    f"output {list(channels_zyx.keys())}, using first channel"
                 )
-                selected = next(iter(channels.values()))
-            current_stack = selected.detach()
+                selected = next(iter(channels_zyx.values()))
+            current_stack_zyx = selected.detach()
             logger.debug(
                 f"DynaTrack[mem]: after channel select p={position_index} t={timepoint_index} "
                 f"rss={_rss_gb():.2f} GB"
             )
 
         # Store reference on first encounter
-        if position_index not in self._reference_stacks:
-            self._reference_stacks[position_index] = current_stack
-            ref_total = sum(a.nbytes for a in self._reference_stacks.values())
+        if position_index not in self._reference_stacks_zyx:
+            self._reference_stacks_zyx[position_index] = current_stack_zyx
+            ref_total = sum(a.nbytes for a in self._reference_stacks_zyx.values())
             logger.info(
                 f"DynaTrack: stored reference stack for p={position_index} "
-                f"(shape={current_stack.shape})"
+                f"(zyx_shape={current_stack_zyx.shape})"
+
             )
             logger.debug(
                 f"DynaTrack[mem]: after store_ref p={position_index} t={timepoint_index} "
-                f"rss={_rss_gb():.2f} GB refs={len(self._reference_stacks)} "
+                f"rss={_rss_gb():.2f} GB refs={len(self._reference_stacks_zyx)} "
                 f"refs_total={ref_total / 1024**3:.2f} GB"
             )
             return position
@@ -500,13 +501,13 @@ class DynaTrackUpdater(PositionUpdater):
             )
             return position
 
-        reference_stack = self._reference_stacks[position_index]
+        reference_stack_zyx = self._reference_stacks_zyx[position_index]
         logger.debug(
             f"DynaTrack[mem]: before compute_shift p={position_index} t={timepoint_index} "
             f"rss={_rss_gb():.2f} GB"
         )
         t_pcc = _time.monotonic()
-        shift_xyz = self._compute_shift(reference_stack, current_stack)
+        shift_zyx = self._compute_shift(reference_stack_zyx, current_stack_zyx)
         logger.info(f"DynaTrack: phase cross corr took {_time.monotonic() - t_pcc:.2f}s")
         logger.debug(
             f"DynaTrack[mem]: after compute_shift p={position_index} t={timepoint_index} "
@@ -517,17 +518,21 @@ class DynaTrackUpdater(PositionUpdater):
         if "deskew" in self._config.preprocessing:
             # Deskew rotates the volume in the XY plate
             # Swap X/Y shift to match this rotation.
-            _x = position.x + shift_xyz[1]
-            _y = position.y + shift_xyz[0]
+            # 
+            _x = position.x + shift_zyx[1]
+            _y = position.y + shift_zyx[0]
+
+
+            
         else:
-            _x = position.x + shift_xyz[0]
-            _y = position.y + shift_xyz[1]
-        _z = (position.z or 0) + shift_xyz[2] if position.z is not None else None
+            _x = position.x + shift_zyx[2]
+            _y = position.y + shift_zyx[1]
+        _z = (position.z or 0) + shift_zyx[0] if position.z is not None else None
         updated = PositionCoordinates(_x, _y, _z)
 
         logger.info(
             f"DynaTrack: p={position_index} t={timepoint_index} "
-            f"shift=({shift_xyz[0]:.2f}, {shift_xyz[1]:.2f}, {shift_xyz[2]:.2f})"
+            f"shift_zyx=({shift_zyx[0]:.2f}, {shift_zyx[1]:.2f}, {shift_zyx[2]:.2f})"
         )
 
         # Log shift to CSV immediately
@@ -548,16 +553,16 @@ class DynaTrackUpdater(PositionUpdater):
 
     def _compute_shift(
         self,
-        reference: torch.Tensor,
-        current: torch.Tensor,
+        reference_zyx: torch.Tensor,
+        current_zyx: torch.Tensor,
     ) -> tuple[float, float, float]:
         """Compute the (x, y, z) shift between reference and current z-stacks.
 
         Parameters
         ----------
-        reference : torch.Tensor
+        reference_zyx : torch.Tensor
             Reference z-stack, shape (Z, Y, X).
-        current : torch.Tensor
+        current_zyx : torch.Tensor
             Current z-stack, shape (Z, Y, X).
 
         Returns
@@ -568,7 +573,7 @@ class DynaTrackUpdater(PositionUpdater):
         cfg = self._config
 
         # 1. Phase cross-correlation in pixel space (returns ZYX order)
-        shifts_zyx_px = _phase_cross_corr(reference, current, cfg.maximum_shift)
+        shifts_zyx_px = _phase_cross_corr(reference_zyx, current_zyx, cfg.maximum_shift)
 
         # 2. Convert pixels to microns
         shifts_zyx_um = np.array(
@@ -596,11 +601,11 @@ class DynaTrackUpdater(PositionUpdater):
         )
 
         # 5. Reorder from (z, y, x) to (x, y, z) for PositionCoordinates
-        x_um = float(shifts_zyx_um[2])
-        y_um = float(shifts_zyx_um[1])
-        z_um = float(shifts_zyx_um[0])
+        # x_um = float(shifts_zyx_um[2])
+        # y_um = float(shifts_zyx_um[1])
+        # z_um = float(shifts_zyx_um[0])
 
-        return (x_um, y_um, z_um)
+        return shifts_zyx_um
 
     def _save_debug_channels(
         self,

--- a/shrimpy/mantis/dynatrack.py
+++ b/shrimpy/mantis/dynatrack.py
@@ -95,6 +95,7 @@ class DynaTrackConfig:
     deskew_config: dict[str, Any] | None = None
     phase_config: dict[str, Any] | None = None
     vs_config: dict[str, Any] | None = None
+    image_to_stage_matrix_xyz: list[list[float]] | None = None
     shift_log_path: str | Path | None = None
     save_debug: bool = False
 
@@ -507,32 +508,34 @@ class DynaTrackUpdater(PositionUpdater):
             f"rss={_rss_gb():.2f} GB"
         )
         t_pcc = _time.monotonic()
-        shift_zyx = self._compute_shift(reference_stack_zyx, current_stack_zyx)
+        shift_image_xyz = self._compute_shift(reference_stack_zyx, current_stack_zyx)
         logger.info(f"DynaTrack: phase cross corr took {_time.monotonic() - t_pcc:.2f}s")
         logger.debug(
             f"DynaTrack[mem]: after compute_shift p={position_index} t={timepoint_index} "
             f"rss={_rss_gb():.2f} GB"
         )
 
-        # NOTE the signs
-        if "deskew" in self._config.preprocessing:
-            # Deskew rotates the volume in the XY plate
-            # Swap X/Y shift to match this rotation.
-            # 
-            _x = position.x + shift_zyx[1]
-            _y = position.y + shift_zyx[0]
 
+        # 1. Decouple position in image space from position in stage space
+        # First get the stage position in image space with configurable transform matrix
+        # Add the shift to get the new position in image space
+        # Convert the new position in image space to stage position
+        # Update the position in stage space
 
-            
+        if self._config.image_to_stage_matrix_xyz is not None:
+            T = np.asarray(self._config.image_to_stage_matrix_xyz)
+            shift_stage_xyz = T @ shift_image_xyz
         else:
-            _x = position.x + shift_zyx[2]
-            _y = position.y + shift_zyx[1]
-        _z = (position.z or 0) + shift_zyx[0] if position.z is not None else None
+            shift_stage_xyz = shift_image_xyz
+
+        _x = position.x + shift_stage_xyz[0]
+        _y = position.y + shift_stage_xyz[1]
+        _z = (position.z or 0) + shift_stage_xyz[2] if position.z is not None else None
         updated = PositionCoordinates(_x, _y, _z)
 
         logger.info(
             f"DynaTrack: p={position_index} t={timepoint_index} "
-            f"shift_zyx=({shift_zyx[0]:.2f}, {shift_zyx[1]:.2f}, {shift_zyx[2]:.2f})"
+            f"shift_xyz_um=({shift_image_xyz[0]:.2f}, {shift_image_xyz[1]:.2f}, {shift_image_xyz[2]:.2f})"
         )
 
         # Log shift to CSV immediately
@@ -601,11 +604,11 @@ class DynaTrackUpdater(PositionUpdater):
         )
 
         # 5. Reorder from (z, y, x) to (x, y, z) for PositionCoordinates
-        # x_um = float(shifts_zyx_um[2])
-        # y_um = float(shifts_zyx_um[1])
-        # z_um = float(shifts_zyx_um[0])
+        x_um = float(shifts_zyx_um[2])
+        y_um = float(shifts_zyx_um[1])
+        z_um = float(shifts_zyx_um[0])
 
-        return shifts_zyx_um
+        return (x_um, y_um, z_um)
 
     def _save_debug_channels(
         self,

--- a/shrimpy/mantis/dynatrack.py
+++ b/shrimpy/mantis/dynatrack.py
@@ -438,7 +438,7 @@ class DynaTrackUpdater(PositionUpdater):
         # All downstream ops run on tensors. Move to CUDA if available;
         # the preprocessor (if any) already targets the same device.
         device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-        current_stack: torch.Tensor = torch.as_tensor(
+        current_stack_zyx: torch.Tensor = torch.as_tensor(
             raw_stack, device=device, dtype=torch.float32
         )
 

--- a/shrimpy/mantis/dynatrack.py
+++ b/shrimpy/mantis/dynatrack.py
@@ -528,9 +528,12 @@ class DynaTrackUpdater(PositionUpdater):
         else:
             shift_stage_xyz = shift_image_xyz
 
-        _x = position.x + shift_stage_xyz[0]
-        _y = position.y + shift_stage_xyz[1]
-        _z = (position.z or 0) + shift_stage_xyz[2] if position.z is not None else None
+        # The shift is the measured drift of the current image relative to the
+        # reference, so the stage must move in the OPPOSITE direction to
+        # recenter -- hence subtract.
+        _x = position.x - shift_stage_xyz[0]
+        _y = position.y - shift_stage_xyz[1]
+        _z = (position.z or 0) - shift_stage_xyz[2] if position.z is not None else None
         updated = PositionCoordinates(_x, _y, _z)
 
         logger.info(

--- a/shrimpy/mantis/dynatrack.py
+++ b/shrimpy/mantis/dynatrack.py
@@ -482,7 +482,6 @@ class DynaTrackUpdater(PositionUpdater):
             logger.info(
                 f"DynaTrack: stored reference stack for p={position_index} "
                 f"(zyx_shape={current_stack_zyx.shape})"
-
             )
             logger.debug(
                 f"DynaTrack[mem]: after store_ref p={position_index} t={timepoint_index} "
@@ -515,18 +514,16 @@ class DynaTrackUpdater(PositionUpdater):
             f"rss={_rss_gb():.2f} GB"
         )
 
-
         # 1. Decouple position in image space from position in stage space
         # First get the stage position in image space with configurable transform matrix
         # Add the shift to get the new position in image space
         # Convert the new position in image space to stage position
         # Update the position in stage space
 
-        if self._config.image_to_stage_matrix_xyz is not None:
-            T = np.asarray(self._config.image_to_stage_matrix_xyz)
-            shift_stage_xyz = T @ shift_image_xyz
-        else:
-            shift_stage_xyz = shift_image_xyz
+        image_to_stage_matrix_xyz = self._config.image_to_stage_matrix_xyz
+        if image_to_stage_matrix_xyz is None:
+            image_to_stage_matrix_xyz = np.eye(3)
+        shift_stage_xyz = image_to_stage_matrix_xyz @ shift_image_xyz
 
         # The shift is the measured drift of the current image relative to the
         # reference, so the stage must move in the OPPOSITE direction to

--- a/shrimpy/tests/test_dynatrack.py
+++ b/shrimpy/tests/test_dynatrack.py
@@ -269,7 +269,7 @@ class TestDynaTrackUpdaterFlow:
         assert result.x == 100.0
         assert result.y == 200.0
         assert result.z == 50.0
-        assert 0 in updater._reference_stacks
+        assert 0 in updater._reference_stacks_zyx
 
     def test_second_call_detects_shift(self):
         """Second call computes a shift and returns an updated position."""


### PR DESCRIPTION
Closes #279. Sub-PR of #267.

Sub-PR 1/6 of the split of #273 / #278 into goal-scoped reviewable units. Base is `256-position-update-infrastructure` (#257).

## Summary

Makes DynaTrack stage-drift corrections converge on-microscope. Two coupled fixes:

1. **Configurable per-scope image→stage matrix.** Add `image_to_stage_matrix_xyz` at the dynatrack config level so the image→stage relationship can be calibrated per scope. Fix the demo matrix from a reflection (det -1) to a proper 90° rotation (det +1).
2. **Negative-feedback direction.** Apply the shift as `updated = position - shift` (was `+ shift`), so the stage moves opposite the measured drift to recenter. The prior `+shift` amplified drift on any axis that cleared the deadband.

Also: rename internal shift/stack variables to make ZYX vs XYZ order explicit (e.g. `current_stack` → `current_stack_zyx`).

## Test plan

- [x] No test regressions vs `256-position-update-infrastructure` baseline.
- [x] On-microscope (validated upstream on #273): 9 positions × 5 timepoints — both in-plane axes converge to deadband, no runaway.

## Commits

Cherry-picked from #273 (preserving original authorship):
- Rename variables to clarify ZYX axis order
- Add configurable image-to-stage transform matrix
- Move `image_to_stage_matrix_xyz` to dynatrack config level
- Fix correction direction (negative feedback + matrix handedness)

Plus one small fixup to complete the `current_stack → current_stack_zyx` rename for the no-preprocessor path.