### PR TITLE
DynaTrack: bound position-update executor queue with timepoint-boundary drain

### DIFF
--- a/shrimpy/mantis/mantis_engine.py
+++ b/shrimpy/mantis/mantis_engine.py
@@ -253,9 +253,24 @@ class MantisEngine(MDAEngine):
         By applying position updates here (before the MDA runner emits
         ``eventStarted``), the logged event reflects the corrected
         coordinates rather than the original sequence values.
+
+        At timepoint boundaries the iterator drains any pending DynaTrack
+        update so that (a) position corrections are applied before the new
+        timepoint starts and (b) frame data does not accumulate unboundedly
+        in the executor queue.
         """
+        last_t: int | None = None
         for event in super().event_iterator(events):
             if self._position_update_manager is not None:
+                idx = (
+                    event.events[0].index
+                    if isinstance(event, SequencedEvent)
+                    else event.index
+                )
+                t_idx = idx.get("t", 0)
+                if last_t is not None and t_idx != last_t:
+                    self._position_update_manager.drain_pending()
+                last_t = t_idx
                 event = self._position_update_manager.apply_position_update(event)
             yield event
 

--- a/shrimpy/mantis/position_update.py
+++ b/shrimpy/mantis/position_update.py
@@ -237,6 +237,20 @@ class PositionUpdateManager:
                 self._executor = ThreadPoolExecutor(max_workers=1)
             self._pending_future = None
 
+    def drain_pending(self, timeout: float = 120) -> None:
+        """Block until the in-flight position update completes.
+
+        Called at timepoint boundaries to apply backpressure: the
+        acquisition pauses briefly between timepoints rather than
+        accumulating unbounded frame data in the executor queue.
+        """
+        if self._pending_future is not None and not self._pending_future.done():
+            logger.info("Draining pending position update before next timepoint...")
+            try:
+                self._pending_future.result(timeout=timeout)
+            except Exception:
+                logger.warning("Pending position update timed out or failed during drain")
+
     def shutdown(self) -> None:
         """Shutdown the executor and worker process."""
         # Drain final result from worker process

--- a/shrimpy/tests/test_position_update.py
+++ b/shrimpy/tests/test_position_update.py
@@ -716,16 +716,25 @@ class TestBackpressure:
 
         manager.shutdown()
 
-        # Count how many times a new submission found a still-pending future.
-        # With drain at timepoint boundaries, this should be rare (only
-        # within a single timepoint where positions complete quickly).
-        # Without drain, most submissions after the first will find a
-        # pending future because the slow updater can't keep up.
+        # Within a single timepoint, overlaps are expected: 3 positions
+        # submit faster than the 0.3s updater processes them, so positions
+        # 2 and 3 find position 1 still pending. That's fine — the drain
+        # only fires between timepoints.
+        #
+        # Without drain: nearly all submissions overlap (11/12).
+        # With drain: at most (positions_per_timepoint - 1) per timepoint,
+        # i.e. 2 × 4 = 8 out of 12. The key is no cross-timepoint
+        # accumulation — the queue never holds more than one timepoint's
+        # worth of work.
+        n_positions = 3
+        n_timepoints = 4
+        max_expected_overlaps = (n_positions - 1) * n_timepoints
         overlaps = sum(pending_at_submit)
         total = len(pending_at_submit)
-        assert overlaps <= total // 2, (
-            f"{overlaps}/{total} submissions found a pending future — "
-            "executor queue is growing without backpressure"
+        assert overlaps <= max_expected_overlaps, (
+            f"{overlaps}/{total} submissions found a pending future "
+            f"(expected at most {max_expected_overlaps}) — "
+            "executor queue is accumulating across timepoints"
         )
 
 

--- a/shrimpy/tests/test_position_update.py
+++ b/shrimpy/tests/test_position_update.py
@@ -576,6 +576,159 @@ class TestMantisEnginePositionUpdate:
 # ---------------------------------------------------------------------------
 
 
+class TestBackpressure:
+    """Verify that position update drains pending work at timepoint boundaries.
+
+    Without backpressure, a slow updater causes frame data to accumulate
+    unboundedly in the ThreadPoolExecutor queue — one full z-stack per
+    position per timepoint. This eventually exhausts RAM and triggers
+    MemoryError: Buffer overflowed from the Micro-Manager circular buffer.
+    """
+
+    def test_slow_updater_queue_bounded_across_timepoints(self, engine):
+        """Pending updates must be drained between timepoints.
+
+        Simulate a slow updater (0.5s per position) across 3 timepoints
+        with 3 positions and 2 z-slices each. Record when each event is
+        *yielded* by event_iterator and when each update *completes*.
+
+        Without backpressure, event_iterator yields timepoint 1 events
+        immediately while timepoint 0 updates are still running on the
+        executor. With drain, event_iterator blocks at the boundary until
+        the pending update finishes, so all t=0 updates complete before
+        any t=1 event is yielded.
+        """
+        store = PositionStore()
+        for i in range(3):
+            store.update_position(i, x=float(i * 100), y=float(i * 100), z=0.0)
+
+        update_completions: list[tuple[int, int, float]] = []
+        event_yields: list[tuple[int, int, float]] = []
+
+        class SlowUpdater(PositionUpdater):
+            def update(self, t_idx, p_idx, position, data=None):
+                time.sleep(0.5)
+                update_completions.append((t_idx, p_idx, time.monotonic()))
+                return position
+
+        config = PositionUpdateConfig(enabled=True, update_channel=0)
+        manager = PositionUpdateManager(config, store, updater=SlowUpdater())
+        manager.start()
+
+        engine._position_update_manager = manager
+        engine._position_update_frames = {}
+        engine._position_update_expected_slices = 2
+
+        # Build events: 3 timepoints × 3 positions × 2 z-slices
+        events = []
+        for t in range(3):
+            for p in range(3):
+                for z in range(2):
+                    events.append(MDAEvent(
+                        index={"t": t, "p": p, "c": 0, "z": z},
+                        x_pos=float(p * 100),
+                        y_pos=float(p * 100),
+                    ))
+
+        frame = np.zeros((64, 64), dtype=np.uint16)
+
+        with patch("shrimpy.mantis.mantis_engine.MDAEngine.event_iterator", return_value=iter(events)):
+            for event in engine.event_iterator(events):
+                t_idx = event.index.get("t", 0)
+                p_idx = event.index.get("p", 0)
+                event_yields.append((t_idx, p_idx, time.monotonic()))
+                engine._on_frame_ready(frame, event)
+
+        manager.shutdown()
+
+        # All 9 updates should have completed (3t × 3p)
+        assert len(update_completions) == 9
+
+        # The critical check: when event_iterator yields the first event
+        # of timepoint 1, all timepoint 0 updates must already be done.
+        t0_last_completion = max(ts for t, p, ts in update_completions if t == 0)
+        t1_first_yield = min(ts for t, p, ts in event_yields if t == 1)
+
+        assert t0_last_completion < t1_first_yield, (
+            f"Timepoint 0 last update completed at {t0_last_completion:.3f}, "
+            f"but timepoint 1 first event yielded at {t1_first_yield:.3f} — "
+            "event_iterator is not draining pending updates at timepoint boundary"
+        )
+
+    def test_executor_queue_depth_bounded(self, engine):
+        """The executor should not accumulate more than one pending future.
+
+        Without backpressure, on_position_complete submits to the executor
+        without waiting — the internal queue grows by one z-stack per
+        position. With drain at timepoint boundaries, the queue is flushed
+        before new work is submitted.
+
+        We measure this by counting how many futures are submitted while
+        previous ones are still pending.
+        """
+        store = PositionStore()
+        for i in range(3):
+            store.update_position(i, x=float(i * 100), y=float(i * 100), z=0.0)
+
+        pending_at_submit: list[int] = []
+        _orig_submit = PositionUpdateManager.on_position_complete
+
+        class SlowUpdater(PositionUpdater):
+            def update(self, t_idx, p_idx, position, data=None):
+                time.sleep(0.3)
+                return position
+
+        config = PositionUpdateConfig(enabled=True, update_channel=0)
+        manager = PositionUpdateManager(config, store, updater=SlowUpdater())
+        manager.start()
+
+        # Monkey-patch to track whether a future is still pending at submit time
+        orig_on_position_complete = manager.on_position_complete.__func__
+
+        def tracking_on_position_complete(self_mgr, t_idx, p_idx, data=None):
+            if self_mgr._pending_future is not None and not self_mgr._pending_future.done():
+                pending_at_submit.append(1)
+            else:
+                pending_at_submit.append(0)
+            return orig_on_position_complete(self_mgr, t_idx, p_idx, data)
+
+        manager.on_position_complete = lambda t, p, data=None: tracking_on_position_complete(manager, t, p, data)
+
+        engine._position_update_manager = manager
+        engine._position_update_frames = {}
+        engine._position_update_expected_slices = 1
+
+        # 4 timepoints × 3 positions × 1 z-slice
+        events = []
+        for t in range(4):
+            for p in range(3):
+                events.append(MDAEvent(
+                    index={"t": t, "p": p, "c": 0, "z": 0},
+                    x_pos=float(p * 100),
+                    y_pos=float(p * 100),
+                ))
+
+        frame = np.zeros((64, 64), dtype=np.uint16)
+
+        with patch("shrimpy.mantis.mantis_engine.MDAEngine.event_iterator", return_value=iter(events)):
+            for event in engine.event_iterator(events):
+                engine._on_frame_ready(frame, event)
+
+        manager.shutdown()
+
+        # Count how many times a new submission found a still-pending future.
+        # With drain at timepoint boundaries, this should be rare (only
+        # within a single timepoint where positions complete quickly).
+        # Without drain, most submissions after the first will find a
+        # pending future because the slow updater can't keep up.
+        overlaps = sum(pending_at_submit)
+        total = len(pending_at_submit)
+        assert overlaps <= total // 2, (
+            f"{overlaps}/{total} submissions found a pending future — "
+            "executor queue is growing without backpressure"
+        )
+
+
 class TestPositionUpdateIntegration:
     def test_positions_shift_across_acquisitions(self, demo_core, mantis_metadata):
         """End-to-end: a mock updater shifts position by (+1, +1, +0.5) per call.


### PR DESCRIPTION
Closes #280. Sub-PR of #267. Stacks on #283 (PR-1).

Sub-PR 2/6.

## Summary

When the position updater (DynaTrack) is slower than the acquisition rate, the `ThreadPoolExecutor` queue and frame buffer grow unbounded, eventually crashing with `MemoryError: Buffer overflowed`.

## Fix

- `PositionUpdateManager.drain_pending()` blocks until all queued updates complete.
- `event_iterator` calls `drain_pending()` at each timepoint boundary, bounding the queue.

## Test plan

- [x] Regression tests for unbounded executor queue growth (in 169f6eb — fail without the drain).
- [x] Drain implementation (in f3c3d4d) makes the regression tests pass.
- [x] No new test regressions vs PR-1 baseline.

## Commits

Cherry-picked from #273 (preserving Justin Eskesen as author):
- Add failing tests for unbounded executor queue growth
- Drain pending position updates at timepoint boundaries