### PR TITLE
DynaTrack: anchor shifts to acquired stage coords + trim GPU memory

### DIFF
--- a/shrimpy/mantis/dynatrack.py
+++ b/shrimpy/mantis/dynatrack.py
@@ -531,7 +531,8 @@ class DynaTrackUpdater(PositionUpdater):
         # Add the shift to get the new position in image space
         # Convert the new position in image space to stage position
         # Update the position in stage space
-        if transform_xyz := self._config.image_to_stage_matrix_xyz is not None:
+        transform_xyz = self._config.image_to_stage_matrix_xyz
+        if transform_xyz is not None:
             shift_stage_xyz = np.asarray(transform_xyz) @ shift_image_xyz
             logger.info(
                 f"DynaTrack: applied image-to-stage matrix transform to shift: "

--- a/shrimpy/mantis/dynatrack.py
+++ b/shrimpy/mantis/dynatrack.py
@@ -532,15 +532,15 @@ class DynaTrackUpdater(PositionUpdater):
         # Add the shift to get the new position in image space
         # Convert the new position in image space to stage position
         # Update the position in stage space
-        image_to_stage_matrix_xyz = self._config.image_to_stage_matrix_xyz
-        if image_to_stage_matrix_xyz is None:
-            image_to_stage_matrix_xyz = np.eye(3)
-        shift_stage_xyz = np.asarray(image_to_stage_matrix_xyz) @ shift_image_xyz
-        logger.info(
-            f"DynaTrack: applied image-to-stage matrix transform to shift: "
-            f"image_xyz=({shift_image_xyz[0]:.2f}, {shift_image_xyz[1]:.2f}, {shift_image_xyz[2]:.2f}) um -> "
-            f"stage_xyz=({shift_stage_xyz[0]:.2f}, {shift_stage_xyz[1]:.2f}, {shift_stage_xyz[2]:.2f}) um"
-        )
+        if transform_xyz := self._config.image_to_stage_matrix_xyz is not None:
+            shift_stage_xyz = np.asarray(transform_xyz) @ shift_image_xyz
+            logger.info(
+                f"DynaTrack: applied image-to-stage matrix transform to shift: "
+                f"image_xyz=({shift_image_xyz[0]:.2f}, {shift_image_xyz[1]:.2f}, {shift_image_xyz[2]:.2f}) um -> "
+                f"stage_xyz=({shift_stage_xyz[0]:.2f}, {shift_stage_xyz[1]:.2f}, {shift_stage_xyz[2]:.2f}) um"
+            )
+        else:
+            shift_stage_xyz = shift_image_xyz
 
         # Compensate the drift between the reference and where the stack was
         # actually acquired. `position` is the commanded stage coords at

--- a/shrimpy/mantis/dynatrack.py
+++ b/shrimpy/mantis/dynatrack.py
@@ -400,9 +400,8 @@ class DynaTrackUpdater(PositionUpdater):
             The position that was just acquired.
         position : PositionCoordinates
             Stage coordinates the stack was acquired at. The computed shift is
-            added to this value, so corrections compensate the drift between
-            the reference and where the stack actually was -- not against a
-            store value that a later update may already have moved on.
+            used to adjust this value to compensate for drift relative to the
+            reference.
         data : list[np.ndarray] | None
             Frames acquired for this position (one 2D array per z-slice).
 

--- a/shrimpy/mantis/dynatrack.py
+++ b/shrimpy/mantis/dynatrack.py
@@ -389,6 +389,7 @@ class DynaTrackUpdater(PositionUpdater):
         position_index: int,
         position: PositionCoordinates,
         data: list[np.ndarray] | None = None,
+        acquired_at: PositionCoordinates | None = None,
     ) -> PositionCoordinates:
         """Compute updated position by tracking drift from reference z-stack.
 
@@ -399,9 +400,16 @@ class DynaTrackUpdater(PositionUpdater):
         position_index : int
             The position that was just acquired.
         position : PositionCoordinates
-            Current coordinates for this position.
+            Current coordinates for this position (snapshot of the store at
+            submission time). Used as a fallback baseline only.
         data : list[np.ndarray] | None
             Frames acquired for this position (one 2D array per z-slice).
+        acquired_at : PositionCoordinates | None
+            Stage coordinates at the moment the stack was acquired. The
+            computed shift is added to this value, so corrections compensate
+            the drift between the reference and where the stack actually was.
+            Falling back to ``position`` when ``None`` reproduces the previous
+            (race-prone) behaviour.
 
         Returns
         -------
@@ -482,7 +490,6 @@ class DynaTrackUpdater(PositionUpdater):
             logger.info(
                 f"DynaTrack: stored reference stack for p={position_index} "
                 f"(zyx_shape={current_stack_zyx.shape})"
-
             )
             logger.debug(
                 f"DynaTrack[mem]: after store_ref p={position_index} t={timepoint_index} "
@@ -515,7 +522,6 @@ class DynaTrackUpdater(PositionUpdater):
             f"rss={_rss_gb():.2f} GB"
         )
 
-
         # 1. Decouple position in image space from position in stage space
         # First get the stage position in image space with configurable transform matrix
         # Add the shift to get the new position in image space
@@ -523,19 +529,41 @@ class DynaTrackUpdater(PositionUpdater):
         # Update the position in stage space
 
         if self._config.image_to_stage_matrix_xyz is not None:
-            T = np.asarray(self._config.image_to_stage_matrix_xyz)
-            shift_stage_xyz = T @ shift_image_xyz
+            transform_xyz = np.asarray(self._config.image_to_stage_matrix_xyz)
+            shift_stage_xyz = transform_xyz @ shift_image_xyz
+            logger.info(
+                f"DynaTrack: applied image-to-stage matrix transform to shift: "
+                f"image_xyz=({shift_image_xyz[0]:.2f}, {shift_image_xyz[1]:.2f}, {shift_image_xyz[2]:.2f}) um -> "
+                f"stage_xyz=({shift_stage_xyz[0]:.2f}, {shift_stage_xyz[1]:.2f}, {shift_stage_xyz[2]:.2f}) um"
+            )
         else:
             shift_stage_xyz = shift_image_xyz
 
+        # Compensate the drift between the reference and where the stack was
+        # actually acquired. Using `acquired_at` (the commanded stage coords
+        # at acquisition time) as the baseline avoids accumulating shifts when
+        # a previous update lands too late to influence the next acquisition.
         # The shift is the measured drift of the current image relative to the
         # reference, so the stage must move in the OPPOSITE direction to
         # recenter -- hence subtract.
-        _x = position.x - shift_stage_xyz[0]
-        _y = position.y - shift_stage_xyz[1]
-        _z = (position.z or 0) - shift_stage_xyz[2] if position.z is not None else None
+        baseline = acquired_at if acquired_at is not None else position
+        if acquired_at is None:
+            logger.warning(
+                f"DynaTrack: no acquired_at for p={position_index} t={timepoint_index}, "
+                f"falling back to current store value (race-prone)"
+            )
+        logger.info(
+            f"DynaTrack: baseline (acquired_at) p={position_index} t={timepoint_index} "
+            f"x={baseline.x} y={baseline.y} z={baseline.z}"
+        )
+        _x = baseline.x - shift_stage_xyz[0]
+        _y = baseline.y - shift_stage_xyz[1]
+        _z = (baseline.z or 0) - shift_stage_xyz[2] if baseline.z is not None else None
         updated = PositionCoordinates(_x, _y, _z)
-
+        logger.info(
+            f"DynaTrack: updated position p={position_index} t={timepoint_index} "
+            f"x={updated.x} y={updated.y} z={updated.z}"
+        )
         logger.info(
             f"DynaTrack: p={position_index} t={timepoint_index} "
             f"shift_xyz_um=({shift_image_xyz[0]:.2f}, {shift_image_xyz[1]:.2f}, {shift_image_xyz[2]:.2f})"

--- a/shrimpy/mantis/dynatrack.py
+++ b/shrimpy/mantis/dynatrack.py
@@ -389,7 +389,6 @@ class DynaTrackUpdater(PositionUpdater):
         position_index: int,
         position: PositionCoordinates,
         data: list[np.ndarray] | None = None,
-        acquired_at: PositionCoordinates | None = None,
     ) -> PositionCoordinates:
         """Compute updated position by tracking drift from reference z-stack.
 
@@ -400,16 +399,12 @@ class DynaTrackUpdater(PositionUpdater):
         position_index : int
             The position that was just acquired.
         position : PositionCoordinates
-            Current coordinates for this position (snapshot of the store at
-            submission time). Used as a fallback baseline only.
+            Stage coordinates the stack was acquired at. The computed shift is
+            added to this value, so corrections compensate the drift between
+            the reference and where the stack actually was -- not against a
+            store value that a later update may already have moved on.
         data : list[np.ndarray] | None
             Frames acquired for this position (one 2D array per z-slice).
-        acquired_at : PositionCoordinates | None
-            Stage coordinates at the moment the stack was acquired. The
-            computed shift is added to this value, so corrections compensate
-            the drift between the reference and where the stack actually was.
-            Falling back to ``position`` when ``None`` reproduces the previous
-            (race-prone) behaviour.
 
         Returns
         -------
@@ -446,9 +441,6 @@ class DynaTrackUpdater(PositionUpdater):
         # All downstream ops run on tensors. Move to CUDA if available;
         # the preprocessor (if any) already targets the same device.
         device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-        current_stack_zyx: torch.Tensor = torch.as_tensor(
-            raw_stack, device=device, dtype=torch.float32
-        )
 
         # Apply optional preprocessing (e.g. phase reconstruction, VS).
         # Preprocessor returns torch tensors on device; convert to numpy at
@@ -477,11 +469,24 @@ class DynaTrackUpdater(PositionUpdater):
                     f"output {list(channels_zyx.keys())}, using first channel"
                 )
                 selected = next(iter(channels_zyx.values()))
-            current_stack_zyx = selected.detach()
+            # Clone into a compact standalone tensor. A bare ``.detach()`` is a
+            # view that keeps the *entire* preprocessor output alive (all
+            # channels share one parent tensor), so a stored reference would
+            # pin every channel, not just this one. Cloning lets the other
+            # channels + parent be freed below.
+            current_stack_zyx = selected.detach().clone()
+            # Drop the dict + view and return the freed blocks to the GPU so
+            # the caching allocator does not stay pinned at the VS peak.
+            del channels_zyx, selected
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
             logger.debug(
                 f"DynaTrack[mem]: after channel select p={position_index} t={timepoint_index} "
                 f"rss={_rss_gb():.2f} GB"
             )
+        else:
+            # No preprocessing: move the raw stack to the device directly.
+            current_stack_zyx = torch.as_tensor(raw_stack, device=device, dtype=torch.float32)
 
         # Store reference on first encounter
         if position_index not in self._reference_stacks_zyx:
@@ -540,20 +545,15 @@ class DynaTrackUpdater(PositionUpdater):
             shift_stage_xyz = shift_image_xyz
 
         # Compensate the drift between the reference and where the stack was
-        # actually acquired. Using `acquired_at` (the commanded stage coords
-        # at acquisition time) as the baseline avoids accumulating shifts when
-        # a previous update lands too late to influence the next acquisition.
+        # actually acquired. `position` is the commanded stage coords at
+        # acquisition time, so subtracting the shift here avoids accumulating
+        # against a store value that a later update may already have moved on.
         # The shift is the measured drift of the current image relative to the
         # reference, so the stage must move in the OPPOSITE direction to
         # recenter -- hence subtract.
-        baseline = acquired_at if acquired_at is not None else position
-        if acquired_at is None:
-            logger.warning(
-                f"DynaTrack: no acquired_at for p={position_index} t={timepoint_index}, "
-                f"falling back to current store value (race-prone)"
-            )
+        baseline = position
         logger.info(
-            f"DynaTrack: baseline (acquired_at) p={position_index} t={timepoint_index} "
+            f"DynaTrack: baseline p={position_index} t={timepoint_index} "
             f"x={baseline.x} y={baseline.y} z={baseline.z}"
         )
         _x = baseline.x - shift_stage_xyz[0]

--- a/shrimpy/mantis/dynatrack_worker.py
+++ b/shrimpy/mantis/dynatrack_worker.py
@@ -81,6 +81,7 @@ class DynaTrackWorker:
         position_index: int,
         position: PositionCoordinates,
         data: list[np.ndarray],
+        acquired_at: PositionCoordinates | None = None,
     ) -> None:
         """Send a job to the worker process (non-blocking)."""
         self._input_queue.put(
@@ -89,6 +90,11 @@ class DynaTrackWorker:
                 "timepoint_index": timepoint_index,
                 "position_index": position_index,
                 "position": (position.x, position.y, position.z),
+                "acquired_at": (
+                    (acquired_at.x, acquired_at.y, acquired_at.z)
+                    if acquired_at is not None
+                    else None
+                ),
                 "data": data,
             }
         )
@@ -204,6 +210,10 @@ def _worker_loop(
             from shrimpy.mantis.position_update import PositionCoordinates
 
             position = PositionCoordinates(x=px, y=py, z=pz)
+            acq = msg.get("acquired_at")
+            acquired_at = (
+                PositionCoordinates(x=acq[0], y=acq[1], z=acq[2]) if acq is not None else None
+            )
             data = msg["data"]
 
             n_frames = len(data) if data else 0
@@ -212,7 +222,7 @@ def _worker_loop(
             )
 
             try:
-                updated = updater.update(t_idx, p_idx, position, data)
+                updated = updater.update(t_idx, p_idx, position, data, acquired_at=acquired_at)
                 elapsed = _time.monotonic() - t0
                 output_queue.put(
                     {

--- a/shrimpy/mantis/dynatrack_worker.py
+++ b/shrimpy/mantis/dynatrack_worker.py
@@ -84,8 +84,8 @@ class DynaTrackWorker:
     ) -> None:
         """Send a job to the worker process (non-blocking).
 
-        ``position`` is the stage baseline the stack was acquired at; the
-        updater adds the computed shift to it.
+        ``position`` carried the stage coordinates where the stack was acquired.
+        It is updated using the computed shift.
         """
         self._input_queue.put(
             {

--- a/shrimpy/mantis/dynatrack_worker.py
+++ b/shrimpy/mantis/dynatrack_worker.py
@@ -81,20 +81,18 @@ class DynaTrackWorker:
         position_index: int,
         position: PositionCoordinates,
         data: list[np.ndarray],
-        acquired_at: PositionCoordinates | None = None,
     ) -> None:
-        """Send a job to the worker process (non-blocking)."""
+        """Send a job to the worker process (non-blocking).
+
+        ``position`` is the stage baseline the stack was acquired at; the
+        updater adds the computed shift to it.
+        """
         self._input_queue.put(
             {
                 "type": "update",
                 "timepoint_index": timepoint_index,
                 "position_index": position_index,
                 "position": (position.x, position.y, position.z),
-                "acquired_at": (
-                    (acquired_at.x, acquired_at.y, acquired_at.z)
-                    if acquired_at is not None
-                    else None
-                ),
                 "data": data,
             }
         )
@@ -210,10 +208,6 @@ def _worker_loop(
             from shrimpy.mantis.position_update import PositionCoordinates
 
             position = PositionCoordinates(x=px, y=py, z=pz)
-            acq = msg.get("acquired_at")
-            acquired_at = (
-                PositionCoordinates(x=acq[0], y=acq[1], z=acq[2]) if acq is not None else None
-            )
             data = msg["data"]
 
             n_frames = len(data) if data else 0
@@ -222,7 +216,7 @@ def _worker_loop(
             )
 
             try:
-                updated = updater.update(t_idx, p_idx, position, data, acquired_at=acquired_at)
+                updated = updater.update(t_idx, p_idx, position, data)
                 elapsed = _time.monotonic() - t0
                 output_queue.put(
                     {
@@ -254,3 +248,13 @@ def _worker_loop(
                         "timepoint_index": t_idx,
                     }
                 )
+
+            # Release this job's GPU working set so reserved memory is not
+            # pinned at the VS-inference peak across positions/timepoints.
+            try:
+                import torch as _torch
+
+                if _torch.cuda.is_available():
+                    _torch.cuda.empty_cache()
+            except Exception:
+                pass

--- a/shrimpy/mantis/mantis_engine.py
+++ b/shrimpy/mantis/mantis_engine.py
@@ -24,6 +24,7 @@ from useq import MDAEvent, MDASequence
 
 from shrimpy.mantis.dynatrack import DynaTrackConfig, DynaTrackUpdater
 from shrimpy.mantis.position_update import (
+    PositionCoordinates,
     PositionStore,
     PositionUpdateConfig,
     PositionUpdateManager,
@@ -92,6 +93,7 @@ class MantisEngine(MDAEngine):
         self._xy_stage_speed = None
         self._position_update_manager: PositionUpdateManager | None = None
         self._position_update_frames: dict[tuple[int, int], list[np.ndarray]] = {}
+        self._position_update_acquired_at: dict[tuple[int, int], PositionCoordinates] = {}
         self._position_update_expected_slices: int = 1
         self._data_path: Path | None = None
 
@@ -173,7 +175,7 @@ class MantisEngine(MDAEngine):
                 updater = DynaTrackUpdater(config=dynatrack_config)
                 # Debug zarr path and position names (activated after preprocessor is built)
                 if dynatrack_config.save_debug and self._data_path:
-                    updater._debug_zarr_path = self._data_path.parent / "dynatrack_debug.zarr"
+                    updater._debug_zarr_path = self._data_path / "dynatrack_debug.zarr"
                     updater._debug_position_names = {
                         idx: pos.name or f"p{idx}"
                         for idx, pos in enumerate(sequence.stage_positions)
@@ -326,11 +328,48 @@ class MantisEngine(MDAEngine):
 
         if tp not in self._position_update_frames:
             self._position_update_frames[tp] = []
+            # Capture the stage coordinates at the moment this stack started
+            # acquiring. Used as the baseline for shift compensation so that
+            # late-arriving updates don't accumulate against stale store values.
+            #
+            # For Z-sequenced acquisitions, per-slice events carry ``event.z_pos``
+            # = slice z (the fast axis), not the focus stage. Read the focus
+            # position from the core directly when ``z_device`` is configured.
+            z_device = self._position_update_manager.config.z_device
+            acq_z: float | None = None
+            if z_device:
+                try:
+                    acq_z = float(self.mmcore.getPosition(z_device))
+                except Exception:
+                    logger.warning(
+                        f"DynaTrack: failed to read {z_device} position for "
+                        f"acquired_at baseline; falling back to event.z_pos"
+                    )
+                    acq_z = None
+            if acq_z is None:
+                acq_z = event.z_pos
+            acq_x = event.x_pos
+            acq_y = event.y_pos
+            if acq_x is None or acq_y is None:
+                try:
+                    cx, cy = self.mmcore.getXYPosition()
+                    if acq_x is None:
+                        acq_x = cx
+                    if acq_y is None:
+                        acq_y = cy
+                except Exception:
+                    pass
+            self._position_update_acquired_at[tp] = PositionCoordinates(
+                x=acq_x if acq_x is not None else 0.0,
+                y=acq_y if acq_y is not None else 0.0,
+                z=acq_z,
+            )
         self._position_update_frames[tp].append(img.copy())
 
         # Flush when all z-slices for this position have arrived
         if len(self._position_update_frames[tp]) >= self._position_update_expected_slices:
             frames = self._position_update_frames.pop(tp)
+            acquired_at = self._position_update_acquired_at.pop(tp, None)
             n_pending_tps = len(self._position_update_frames)
             pending_bytes = sum(
                 sum(a.nbytes for a in frames_list)
@@ -341,13 +380,16 @@ class MantisEngine(MDAEngine):
                 f"rss={_rss_gb():.2f} GB frames_buf_pending={n_pending_tps} "
                 f"({pending_bytes / 1024**3:.2f} GB)"
             )
-            self._position_update_manager.on_position_complete(t_idx, p_idx, frames)
+            self._position_update_manager.on_position_complete(
+                t_idx, p_idx, frames, acquired_at=acquired_at
+            )
 
     def teardown_sequence(self, sequence):
         # Position update: disconnect callback and shutdown
         if self._position_update_manager is not None:
             self.mmcore.mda.events.frameReady.disconnect(self._on_frame_ready)
             self._position_update_frames = {}
+            self._position_update_acquired_at = {}
             self._position_update_manager.shutdown()
             self._position_update_manager = None
 

--- a/shrimpy/mantis/mantis_engine.py
+++ b/shrimpy/mantis/mantis_engine.py
@@ -24,7 +24,6 @@ from useq import MDAEvent, MDASequence
 
 from shrimpy.mantis.dynatrack import DynaTrackConfig, DynaTrackUpdater
 from shrimpy.mantis.position_update import (
-    PositionCoordinates,
     PositionStore,
     PositionUpdateConfig,
     PositionUpdateManager,
@@ -93,7 +92,6 @@ class MantisEngine(MDAEngine):
         self._xy_stage_speed = None
         self._position_update_manager: PositionUpdateManager | None = None
         self._position_update_frames: dict[tuple[int, int], list[np.ndarray]] = {}
-        self._position_update_acquired_at: dict[tuple[int, int], PositionCoordinates] = {}
         self._position_update_expected_slices: int = 1
         self._data_path: Path | None = None
 
@@ -328,48 +326,11 @@ class MantisEngine(MDAEngine):
 
         if tp not in self._position_update_frames:
             self._position_update_frames[tp] = []
-            # Capture the stage coordinates at the moment this stack started
-            # acquiring. Used as the baseline for shift compensation so that
-            # late-arriving updates don't accumulate against stale store values.
-            #
-            # For Z-sequenced acquisitions, per-slice events carry ``event.z_pos``
-            # = slice z (the fast axis), not the focus stage. Read the focus
-            # position from the core directly when ``z_device`` is configured.
-            z_device = self._position_update_manager.config.z_device
-            acq_z: float | None = None
-            if z_device:
-                try:
-                    acq_z = float(self.mmcore.getPosition(z_device))
-                except Exception:
-                    logger.warning(
-                        f"DynaTrack: failed to read {z_device} position for "
-                        f"acquired_at baseline; falling back to event.z_pos"
-                    )
-                    acq_z = None
-            if acq_z is None:
-                acq_z = event.z_pos
-            acq_x = event.x_pos
-            acq_y = event.y_pos
-            if acq_x is None or acq_y is None:
-                try:
-                    cx, cy = self.mmcore.getXYPosition()
-                    if acq_x is None:
-                        acq_x = cx
-                    if acq_y is None:
-                        acq_y = cy
-                except Exception:
-                    pass
-            self._position_update_acquired_at[tp] = PositionCoordinates(
-                x=acq_x if acq_x is not None else 0.0,
-                y=acq_y if acq_y is not None else 0.0,
-                z=acq_z,
-            )
         self._position_update_frames[tp].append(img.copy())
 
         # Flush when all z-slices for this position have arrived
         if len(self._position_update_frames[tp]) >= self._position_update_expected_slices:
             frames = self._position_update_frames.pop(tp)
-            acquired_at = self._position_update_acquired_at.pop(tp, None)
             n_pending_tps = len(self._position_update_frames)
             pending_bytes = sum(
                 sum(a.nbytes for a in frames_list)
@@ -380,16 +341,13 @@ class MantisEngine(MDAEngine):
                 f"rss={_rss_gb():.2f} GB frames_buf_pending={n_pending_tps} "
                 f"({pending_bytes / 1024**3:.2f} GB)"
             )
-            self._position_update_manager.on_position_complete(
-                t_idx, p_idx, frames, acquired_at=acquired_at
-            )
+            self._position_update_manager.on_position_complete(t_idx, p_idx, frames)
 
     def teardown_sequence(self, sequence):
         # Position update: disconnect callback and shutdown
         if self._position_update_manager is not None:
             self.mmcore.mda.events.frameReady.disconnect(self._on_frame_ready)
             self._position_update_frames = {}
-            self._position_update_acquired_at = {}
             self._position_update_manager.shutdown()
             self._position_update_manager = None
 

--- a/shrimpy/mantis/position_update.py
+++ b/shrimpy/mantis/position_update.py
@@ -124,6 +124,7 @@ class PositionUpdater:
         position_index: int,
         position: PositionCoordinates,
         data: list[np.ndarray] | None = None,
+        acquired_at: PositionCoordinates | None = None,
     ) -> PositionCoordinates:
         """Return updated coordinates for the given position.
 
@@ -134,10 +135,15 @@ class PositionUpdater:
         position_index : int
             The position that was just acquired.
         position : PositionCoordinates
-            Current coordinates for this position.
+            Current coordinates for this position (snapshot of the store).
         data : list[np.ndarray] | None
             Frames acquired for this position (one 2D array per z-slice),
             or None if frame collection is not available.
+        acquired_at : PositionCoordinates | None
+            Stage coordinates at the moment the stack was acquired. When
+            provided, subclasses should compute corrections relative to this
+            value rather than ``position``, so late-arriving updates don't
+            accumulate against a store value that has moved on.
 
         Returns
         -------
@@ -273,6 +279,7 @@ class PositionUpdateManager:
         timepoint_index: int,
         position_index: int,
         data: list[np.ndarray] | None = None,
+        acquired_at: PositionCoordinates | None = None,
     ) -> None:
         """Called when a position's z-stack has been fully acquired.
 
@@ -289,7 +296,10 @@ class PositionUpdateManager:
         queue_depth = self._executor._work_queue.qsize()
         logger.debug(
             f"PosUpdateMgr[mem]: before submit p={position_index} t={timepoint_index} "
-            f"rss={_rss_gb():.2f} GB data={data_gb:.2f} GB queue_depth={queue_depth}"
+            f"rss={_rss_gb():.2f} GB data={data_gb:.2f} GB queue_depth={queue_depth} "
+            f"acquired_at=({acquired_at.x if acquired_at else None}, "
+            f"{acquired_at.y if acquired_at else None}, "
+            f"{acquired_at.z if acquired_at else None})"
         )
 
         if self._worker is not None:
@@ -301,10 +311,16 @@ class PositionUpdateManager:
                 position_index,
                 position,
                 data,
+                acquired_at,
             )
         else:
             self._pending_future = self._executor.submit(
-                self._run_updater, timepoint_index, position_index, position, data
+                self._run_updater,
+                timepoint_index,
+                position_index,
+                position,
+                data,
+                acquired_at,
             )
 
         logger.debug(
@@ -318,6 +334,7 @@ class PositionUpdateManager:
         position_index: int,
         position: PositionCoordinates,
         data: list[np.ndarray] | None,
+        acquired_at: PositionCoordinates | None = None,
     ) -> None:
         """Execute the updater and write the result to the position store."""
         import time as _time
@@ -329,7 +346,9 @@ class PositionUpdateManager:
             f"({n_frames} frames)"
         )
         try:
-            updated = self._updater.update(timepoint_index, position_index, position, data)
+            updated = self._updater.update(
+                timepoint_index, position_index, position, data, acquired_at=acquired_at
+            )
             elapsed = _time.monotonic() - t0
             self.position_store.update_position(
                 position_index, updated.x, updated.y, updated.z
@@ -351,13 +370,16 @@ class PositionUpdateManager:
         position_index: int,
         position: PositionCoordinates,
         data: list[np.ndarray] | None,
+        acquired_at: PositionCoordinates | None = None,
     ) -> None:
         """Submit data to the worker and wait for the result.
 
         Runs in a background thread. By serializing submit + wait, only one
         position's frame data is in the mp.Queue at a time, reducing memory.
         """
-        self._worker.submit(timepoint_index, position_index, position, data)
+        self._worker.submit(
+            timepoint_index, position_index, position, data, acquired_at=acquired_at
+        )
         del data  # free main-process copy after it's been pickled to the queue
         result = self._worker.get_result(timeout=120)
         if result is None:

--- a/shrimpy/mantis/position_update.py
+++ b/shrimpy/mantis/position_update.py
@@ -124,7 +124,6 @@ class PositionUpdater:
         position_index: int,
         position: PositionCoordinates,
         data: list[np.ndarray] | None = None,
-        acquired_at: PositionCoordinates | None = None,
     ) -> PositionCoordinates:
         """Return updated coordinates for the given position.
 
@@ -135,15 +134,15 @@ class PositionUpdater:
         position_index : int
             The position that was just acquired.
         position : PositionCoordinates
-            Current coordinates for this position (snapshot of the store).
+            Stage coordinates the stack was acquired at (the coordinates the
+            manager commanded onto the acquisition event). Subclasses compute
+            corrections relative to this value, so late-arriving updates don't
+            accumulate against a store value that has since moved on. Falls
+            back to the live store snapshot only when no acquisition baseline
+            was recorded.
         data : list[np.ndarray] | None
             Frames acquired for this position (one 2D array per z-slice),
             or None if frame collection is not available.
-        acquired_at : PositionCoordinates | None
-            Stage coordinates at the moment the stack was acquired. When
-            provided, subclasses should compute corrections relative to this
-            value rather than ``position``, so late-arriving updates don't
-            accumulate against a store value that has moved on.
 
         Returns
         -------
@@ -175,6 +174,11 @@ class PositionUpdateManager:
         self._executor: ThreadPoolExecutor | None = None
         self._pending_future: Future | None = None
         self._worker = None  # DynaTrackWorker for subprocess mode
+        # Stage coords commanded onto each (timepoint, position) acquisition
+        # event, captured in ``apply_position_update``. Used as the baseline
+        # for shift compensation so late-arriving updates don't accumulate
+        # against a store value that has since moved on.
+        self._acquired_at: dict[tuple[int, int], PositionCoordinates] = {}
 
     def apply_position_update(self, event: MDAEvent) -> MDAEvent:
         """Replace event's x/y/z with current values from the position store.
@@ -186,9 +190,10 @@ class PositionUpdateManager:
         from pymmcore_plus.core._sequencing import SequencedEvent
 
         if isinstance(event, SequencedEvent):
-            p_idx = event.events[0].index.get("p")
+            index = event.events[0].index
         else:
-            p_idx = event.index.get("p")
+            index = event.index
+        p_idx = index.get("p")
 
         if p_idx is None:
             return event
@@ -196,6 +201,13 @@ class PositionUpdateManager:
         coords = self.position_store.get_position(p_idx)
         if coords is None:
             return event
+
+        # Record the coords commanded for this stack as the acquisition
+        # baseline. The first applied event of a (t, p) stack wins; all slice
+        # events of one stack carry the same x/y/focus. Frozen here, this value
+        # is immune to the runner's event pre-fetch race.
+        t_idx = index.get("t", 0)
+        self._acquired_at.setdefault((t_idx, p_idx), coords)
 
         update: dict = {}
         if coords.x is not None:
@@ -274,12 +286,14 @@ class PositionUpdateManager:
             self._executor.shutdown(wait=True)
             self._executor = None
 
+        # Drop any baselines for stacks that never completed (e.g. skipped events)
+        self._acquired_at = {}
+
     def on_position_complete(
         self,
         timepoint_index: int,
         position_index: int,
         data: list[np.ndarray] | None = None,
-        acquired_at: PositionCoordinates | None = None,
     ) -> None:
         """Called when a position's z-stack has been fully acquired.
 
@@ -288,7 +302,17 @@ class PositionUpdateManager:
         if not self.config.enabled or self._executor is None:
             return
 
-        position = self.position_store.get_position(position_index)
+        # Baseline for the correction is the coords this stack was acquired at
+        # (recorded in apply_position_update). Fall back to the live store
+        # snapshot only when no baseline was recorded -- e.g. an event that
+        # never passed through apply_position_update.
+        position = self._acquired_at.pop((timepoint_index, position_index), None)
+        if position is None:
+            logger.warning(
+                f"PosUpdateMgr: no acquisition baseline for p={position_index} "
+                f"t={timepoint_index}, falling back to live store (race-prone)"
+            )
+            position = self.position_store.get_position(position_index)
         if position is None:
             return
 
@@ -297,9 +321,7 @@ class PositionUpdateManager:
         logger.debug(
             f"PosUpdateMgr[mem]: before submit p={position_index} t={timepoint_index} "
             f"rss={_rss_gb():.2f} GB data={data_gb:.2f} GB queue_depth={queue_depth} "
-            f"acquired_at=({acquired_at.x if acquired_at else None}, "
-            f"{acquired_at.y if acquired_at else None}, "
-            f"{acquired_at.z if acquired_at else None})"
+            f"baseline=({position.x}, {position.y}, {position.z})"
         )
 
         if self._worker is not None:
@@ -311,7 +333,6 @@ class PositionUpdateManager:
                 position_index,
                 position,
                 data,
-                acquired_at,
             )
         else:
             self._pending_future = self._executor.submit(
@@ -320,7 +341,6 @@ class PositionUpdateManager:
                 position_index,
                 position,
                 data,
-                acquired_at,
             )
 
         logger.debug(
@@ -334,7 +354,6 @@ class PositionUpdateManager:
         position_index: int,
         position: PositionCoordinates,
         data: list[np.ndarray] | None,
-        acquired_at: PositionCoordinates | None = None,
     ) -> None:
         """Execute the updater and write the result to the position store."""
         import time as _time
@@ -346,9 +365,7 @@ class PositionUpdateManager:
             f"({n_frames} frames)"
         )
         try:
-            updated = self._updater.update(
-                timepoint_index, position_index, position, data, acquired_at=acquired_at
-            )
+            updated = self._updater.update(timepoint_index, position_index, position, data)
             elapsed = _time.monotonic() - t0
             self.position_store.update_position(
                 position_index, updated.x, updated.y, updated.z
@@ -370,16 +387,13 @@ class PositionUpdateManager:
         position_index: int,
         position: PositionCoordinates,
         data: list[np.ndarray] | None,
-        acquired_at: PositionCoordinates | None = None,
     ) -> None:
         """Submit data to the worker and wait for the result.
 
         Runs in a background thread. By serializing submit + wait, only one
         position's frame data is in the mp.Queue at a time, reducing memory.
         """
-        self._worker.submit(
-            timepoint_index, position_index, position, data, acquired_at=acquired_at
-        )
+        self._worker.submit(timepoint_index, position_index, position, data)
         del data  # free main-process copy after it's been pickled to the queue
         result = self._worker.get_result(timeout=120)
         if result is None:

--- a/shrimpy/mantis/position_update.py
+++ b/shrimpy/mantis/position_update.py
@@ -303,17 +303,22 @@ class PositionUpdateManager:
             return
 
         # Baseline for the correction is the coords this stack was acquired at
-        # (recorded in apply_position_update). Fall back to the live store
-        # snapshot only when no baseline was recorded -- e.g. an event that
-        # never passed through apply_position_update.
+        # (recorded in apply_position_update).
         position = self._acquired_at.pop((timepoint_index, position_index), None)
         if position is None:
-            logger.warning(
+            # No acquisition baseline was recorded for this stack. If the store
+            # doesn't track this position at all, there's nothing to update.
+            if self.position_store.get_position(position_index) is None:
+                return
+            # Otherwise the live store value is ahead of where the stack was
+            # actually acquired (the pre-fetch race this anchoring fixes), so
+            # using it as the baseline would overshoot. Skip this correction;
+            # because shifts anchor to the fixed reference, the next timepoint
+            # re-centers fully, so a skipped correction is self-healing.
+            logger.error(
                 f"PosUpdateMgr: no acquisition baseline for p={position_index} "
-                f"t={timepoint_index}, falling back to live store (race-prone)"
+                f"t={timepoint_index}; skipping this correction (next timepoint recovers)"
             )
-            position = self.position_store.get_position(position_index)
-        if position is None:
             return
 
         data_gb = sum(a.nbytes for a in data) / 1024**3 if data else 0.0

--- a/shrimpy/tests/test_dynatrack.py
+++ b/shrimpy/tests/test_dynatrack.py
@@ -375,9 +375,9 @@ class TestPreprocessor:
 
         call_count = [0]
 
-        def identity_preprocessor(stack: np.ndarray) -> np.ndarray:
+        def identity_preprocessor(stack: np.ndarray) -> dict[str, torch.Tensor]:
             call_count[0] += 1
-            return stack
+            return {"raw": torch.as_tensor(stack)}
 
         updater = DynaTrackUpdater(config=config, preprocessor=identity_preprocessor)
         pos = PositionCoordinates(x=100.0, y=200.0, z=50.0)
@@ -399,11 +399,11 @@ class TestPreprocessor:
         # Preprocessor that rolls the stack by 2 pixels in Y
         first_call = [True]
 
-        def shifting_preprocessor(stack: np.ndarray) -> np.ndarray:
+        def shifting_preprocessor(stack: np.ndarray) -> dict[str, torch.Tensor]:
             if first_call[0]:
                 first_call[0] = False
-                return stack
-            return np.roll(stack, 2, axis=1)
+                return {"raw": torch.as_tensor(stack)}
+            return {"raw": torch.as_tensor(np.roll(stack, 2, axis=1))}
 
         updater = DynaTrackUpdater(config=config, preprocessor=shifting_preprocessor)
         pos = PositionCoordinates(x=0.0, y=0.0, z=0.0)

--- a/shrimpy/tests/test_position_update.py
+++ b/shrimpy/tests/test_position_update.py
@@ -185,7 +185,7 @@ class TestPositionUpdater:
         received_data = {}
 
         class TestUpdater(PositionUpdater):
-            def update(self, t_idx, p_idx, position, data=None):
+            def update(self, t_idx, p_idx, position, data=None, **kwargs):
                 received_data["frames"] = data
                 return position
 
@@ -215,7 +215,7 @@ class TestPositionUpdateManager:
         called_with = {}
 
         class SpyUpdater(PositionUpdater):
-            def update(self, t_idx, p_idx, position, data=None):
+            def update(self, t_idx, p_idx, position, data=None, **kwargs):
                 called_with["t_idx"] = t_idx
                 called_with["p_idx"] = p_idx
                 called_with["position"] = position
@@ -237,7 +237,7 @@ class TestPositionUpdateManager:
 
     def test_updates_store_with_results(self, enabled_config, position_store):
         class ShiftUpdater(PositionUpdater):
-            def update(self, t_idx, p_idx, position, data=None):
+            def update(self, t_idx, p_idx, position, data=None, **kwargs):
                 return PositionCoordinates(
                     x=position.x + 10.0,
                     y=position.y + 20.0,
@@ -259,7 +259,7 @@ class TestPositionUpdateManager:
         original = position_store.get_position(0)
 
         class FailingUpdater(PositionUpdater):
-            def update(self, t_idx, p_idx, position, data=None):
+            def update(self, t_idx, p_idx, position, data=None, **kwargs):
                 raise RuntimeError("updater crashed")
 
         manager = PositionUpdateManager(
@@ -279,7 +279,7 @@ class TestPositionUpdateManager:
         completed = threading.Event()
 
         class SlowUpdater(PositionUpdater):
-            def update(self, t_idx, p_idx, position, data=None):
+            def update(self, t_idx, p_idx, position, data=None, **kwargs):
                 time.sleep(0.2)
                 completed.set()
                 return position
@@ -396,7 +396,7 @@ class TestMantisEnginePositionUpdate:
         received_data = {}
 
         class SpyUpdater(PositionUpdater):
-            def update(self, t_idx, p_idx, position, data=None):
+            def update(self, t_idx, p_idx, position, data=None, **kwargs):
                 received_data["frames"] = data
                 return position
 
@@ -748,7 +748,7 @@ class TestPositionUpdateIntegration:
         engine = MantisEngine(demo_core)
 
         class ShiftUpdater(PositionUpdater):
-            def update(self, t_idx, p_idx, position, data=None):
+            def update(self, t_idx, p_idx, position, data=None, **kwargs):
                 return PositionCoordinates(
                     x=position.x + 1.0,
                     y=position.y + 1.0,

--- a/shrimpy/tests/test_position_update.py
+++ b/shrimpy/tests/test_position_update.py
@@ -203,6 +203,15 @@ class TestPositionUpdater:
 # ---------------------------------------------------------------------------
 
 
+def _record_baseline(manager, t, p):
+    """Simulate the event iterator recording the acquisition baseline for
+    (t, p) before the stack's frames complete. The real flow always does this
+    via ``apply_position_update``; without a baseline the manager now skips the
+    correction rather than anchoring it to a race-prone live-store value.
+    """
+    manager.apply_position_update(MDAEvent(index={"t": t, "p": p}))
+
+
 class TestPositionUpdateManager:
     def test_disabled_is_noop(self, disabled_config, position_store):
         manager = PositionUpdateManager(disabled_config, position_store)
@@ -224,6 +233,7 @@ class TestPositionUpdateManager:
 
         manager = PositionUpdateManager(enabled_config, position_store, updater=SpyUpdater())
         manager.start()
+        _record_baseline(manager, 0, 1)
         frames = [np.zeros((4, 4), dtype=np.uint16)]
         manager.on_position_complete(0, 1, data=frames)
         manager._pending_future.result(timeout=5)
@@ -246,6 +256,7 @@ class TestPositionUpdateManager:
 
         manager = PositionUpdateManager(enabled_config, position_store, updater=ShiftUpdater())
         manager.start()
+        _record_baseline(manager, 0, 0)
         manager.on_position_complete(0, 0)
         manager._pending_future.result(timeout=5)
         manager.shutdown()
@@ -266,6 +277,7 @@ class TestPositionUpdateManager:
             enabled_config, position_store, updater=FailingUpdater()
         )
         manager.start()
+        _record_baseline(manager, 0, 0)
         manager.on_position_complete(0, 0)
         manager._pending_future.result(timeout=5)
         manager.shutdown()
@@ -286,6 +298,7 @@ class TestPositionUpdateManager:
 
         manager = PositionUpdateManager(enabled_config, position_store, updater=SlowUpdater())
         manager.start()
+        _record_baseline(manager, 0, 0)
         manager.on_position_complete(0, 0)
         manager.shutdown()
         assert completed.is_set()
@@ -358,11 +371,11 @@ class TestPositionUpdateManager:
         assert seen["position"].y == 200.0
         assert seen["position"].z == 50.0
 
-    def test_updater_falls_back_to_store_without_baseline(
-        self, enabled_config, position_store
-    ):
+    def test_no_baseline_skips_correction(self, enabled_config, position_store):
         """When no acquisition baseline was recorded (event never passed
-        through apply_position_update), fall back to the live store snapshot.
+        through apply_position_update), the correction is skipped rather than
+        anchored to a race-prone live-store value. Because shifts anchor to a
+        fixed reference, the next timepoint re-centers, so skipping is safe.
         """
         seen = {}
 
@@ -375,12 +388,10 @@ class TestPositionUpdateManager:
         manager.start()
         # No apply_position_update call -> no baseline recorded for (0, 0).
         manager.on_position_complete(0, 0)
-        manager._pending_future.result(timeout=5)
+        # Nothing is submitted and the updater is never called.
+        assert manager._pending_future is None
+        assert "position" not in seen
         manager.shutdown()
-
-        assert seen["position"].x == 100.0
-        assert seen["position"].y == 200.0
-        assert seen["position"].z == 50.0
 
 
 # ---------------------------------------------------------------------------
@@ -430,6 +441,7 @@ class TestMantisEnginePositionUpdate:
         store.update_position(0, x=10.0, y=20.0, z=5.0)
         manager = PositionUpdateManager(PositionUpdateConfig(enabled=True), store)
         manager.start()
+        _record_baseline(manager, 0, 0)
         engine._position_update_manager = manager
         engine._position_update_frames = {}
         engine._position_update_expected_slices = 3
@@ -466,6 +478,7 @@ class TestMantisEnginePositionUpdate:
             PositionUpdateConfig(enabled=True), store, updater=SpyUpdater()
         )
         manager.start()
+        _record_baseline(manager, 0, 0)
         engine._position_update_manager = manager
         engine._position_update_frames = {}
         engine._position_update_expected_slices = 2
@@ -488,6 +501,8 @@ class TestMantisEnginePositionUpdate:
         store.update_position(1, x=30.0, y=40.0, z=15.0)
         manager = PositionUpdateManager(PositionUpdateConfig(enabled=True), store)
         manager.start()
+        _record_baseline(manager, 0, 0)
+        _record_baseline(manager, 0, 1)
         engine._position_update_manager = manager
         engine._position_update_frames = {}
         engine._position_update_expected_slices = 2
@@ -686,15 +701,19 @@ class TestBackpressure:
         for t in range(3):
             for p in range(3):
                 for z in range(2):
-                    events.append(MDAEvent(
-                        index={"t": t, "p": p, "c": 0, "z": z},
-                        x_pos=float(p * 100),
-                        y_pos=float(p * 100),
-                    ))
+                    events.append(
+                        MDAEvent(
+                            index={"t": t, "p": p, "c": 0, "z": z},
+                            x_pos=float(p * 100),
+                            y_pos=float(p * 100),
+                        )
+                    )
 
         frame = np.zeros((64, 64), dtype=np.uint16)
 
-        with patch("shrimpy.mantis.mantis_engine.MDAEngine.event_iterator", return_value=iter(events)):
+        with patch(
+            "shrimpy.mantis.mantis_engine.MDAEngine.event_iterator", return_value=iter(events)
+        ):
             for event in engine.event_iterator(events):
                 t_idx = event.index.get("t", 0)
                 p_idx = event.index.get("p", 0)
@@ -754,7 +773,9 @@ class TestBackpressure:
                 pending_at_submit.append(0)
             return orig_on_position_complete(self_mgr, t_idx, p_idx, data)
 
-        manager.on_position_complete = lambda t, p, data=None: tracking_on_position_complete(manager, t, p, data)
+        manager.on_position_complete = lambda t, p, data=None: tracking_on_position_complete(
+            manager, t, p, data
+        )
 
         engine._position_update_manager = manager
         engine._position_update_frames = {}
@@ -764,15 +785,19 @@ class TestBackpressure:
         events = []
         for t in range(4):
             for p in range(3):
-                events.append(MDAEvent(
-                    index={"t": t, "p": p, "c": 0, "z": 0},
-                    x_pos=float(p * 100),
-                    y_pos=float(p * 100),
-                ))
+                events.append(
+                    MDAEvent(
+                        index={"t": t, "p": p, "c": 0, "z": 0},
+                        x_pos=float(p * 100),
+                        y_pos=float(p * 100),
+                    )
+                )
 
         frame = np.zeros((64, 64), dtype=np.uint16)
 
-        with patch("shrimpy.mantis.mantis_engine.MDAEngine.event_iterator", return_value=iter(events)):
+        with patch(
+            "shrimpy.mantis.mantis_engine.MDAEngine.event_iterator", return_value=iter(events)
+        ):
             for event in engine.event_iterator(events):
                 engine._on_frame_ready(frame, event)
 

--- a/shrimpy/tests/test_position_update.py
+++ b/shrimpy/tests/test_position_update.py
@@ -320,6 +320,68 @@ class TestPositionUpdateManager:
         result = manager.apply_position_update(event)
         assert result is event
 
+    def test_updater_baseline_is_acquired_coords_not_advanced_store(
+        self, enabled_config, position_store
+    ):
+        """Regression: the shift must be anchored to the coords the stack was
+        acquired at, not to a store value a later correction has moved on to.
+
+        Reproduces the pre-fetch race that commit a98c22c fixed: if the store
+        is updated between event-apply (acquisition) and on_position_complete,
+        the updater must still receive the acquisition baseline so corrections
+        don't accumulate against a moving target.
+        """
+        seen = {}
+
+        class SpyUpdater(PositionUpdater):
+            def update(self, t_idx, p_idx, position, data=None):
+                seen["position"] = position
+                return position
+
+        manager = PositionUpdateManager(enabled_config, position_store, updater=SpyUpdater())
+        manager.start()
+
+        # 1. Event for (t=0, p=0) is applied -> baseline recorded from the
+        #    store as it stood at acquisition time (100, 200, 50).
+        event = MDAEvent(x_pos=0.0, y_pos=0.0, z_pos=0.0, index={"t": 0, "p": 0})
+        manager.apply_position_update(event)
+
+        # 2. A later correction lands in the store before this stack completes.
+        position_store.update_position(0, x=999.0, y=888.0, z=777.0)
+
+        # 3. Stack completes -> updater must see the acquisition baseline.
+        manager.on_position_complete(0, 0)
+        manager._pending_future.result(timeout=5)
+        manager.shutdown()
+
+        assert seen["position"].x == 100.0
+        assert seen["position"].y == 200.0
+        assert seen["position"].z == 50.0
+
+    def test_updater_falls_back_to_store_without_baseline(
+        self, enabled_config, position_store
+    ):
+        """When no acquisition baseline was recorded (event never passed
+        through apply_position_update), fall back to the live store snapshot.
+        """
+        seen = {}
+
+        class SpyUpdater(PositionUpdater):
+            def update(self, t_idx, p_idx, position, data=None):
+                seen["position"] = position
+                return position
+
+        manager = PositionUpdateManager(enabled_config, position_store, updater=SpyUpdater())
+        manager.start()
+        # No apply_position_update call -> no baseline recorded for (0, 0).
+        manager.on_position_complete(0, 0)
+        manager._pending_future.result(timeout=5)
+        manager.shutdown()
+
+        assert seen["position"].x == 100.0
+        assert seen["position"].y == 200.0
+        assert seen["position"].z == 50.0
+
 
 # ---------------------------------------------------------------------------
 # MantisEngine integration tests


### PR DESCRIPTION
Closes #281. Sub-PR of #267. Stacks on #284 (PR-2).

Sub-PR 3/6.

## Summary

Two related fixes on long-running acquisitions:

**Acquisition-baseline anchoring.** Corrections were anchored to a `PositionStore` snapshot that the runner's event pre-fetch could have already advanced, causing a one-cycle oscillation that diverged on late updates. Capture the stage coords the stack was actually acquired at (first-frame arrival; `mmcore.getPosition` for the focus axis) inside `PositionUpdateManager.apply_position_update` and pass them as `position` to the updater. The shift now compensates the drift between the reference and where the stack actually was.

**GPU memory.** Per-worker GPU memory was growing unbounded:
- Store the selected channel as `.clone()` so the stored reference no longer pins the entire multi-channel preprocessor output via a view (~1 GB → ~0.5 GB per position).
- Drop the channels dict + `torch.cuda.empty_cache()` after channel select and once per worker job.
- Skip the redundant raw→GPU copy when a preprocessor is active.

## Test plan

- [x] Regression tests assert the correction uses the acquisition baseline, not an advanced store value (b8c4229).
- [x] No new test regressions vs PR-2 baseline. +3 tests now pass thanks to b8c4229's stale-assertion fixes.

## Commits

Cherry-picked from #273 (preserving original authorship):
- Anchor DynaTrack shifts to acquired stage coords, not store snapshot (Ivan — first iteration with `acquired_at` parameter)
- DynaTrack: anchor shifts to acquisition baseline; trim GPU memory (Taylla — final form: `acquired_at` removed, baseline captured upstream)

Note: the two commits represent the natural evolution. The second supersedes the `acquired_at` parameter approach with a simpler upstream capture, and adds the GPU memory trim.