### PR TITLE
DynaTrack: periodic reference re-anchor for long timelapses

### DIFF
--- a/config/mda/mantis/dynatrack_demo.yaml
+++ b/config/mda/mantis/dynatrack_demo.yaml
@@ -65,6 +65,11 @@ metadata:
         scale_yx: 0.1494
         scale_z: 0.174
         tracking_interval: 1
+        # Re-anchor the reference every N timepoints (0 = never; keep the fixed
+        # t=0 reference). On a re-anchor timepoint the current stack becomes the
+        # new reference and no correction is applied. Use for long timelapses
+        # where the sample changes enough that matching a stale reference fails.
+        reference_update_interval: 0
         save_debug: true
         # shift_limits:
         #   z: [0.5, 2.0]

--- a/shrimpy/mantis/dynatrack.py
+++ b/shrimpy/mantis/dynatrack.py
@@ -62,6 +62,14 @@ class DynaTrackConfig:
         "y", "x". Shifts below min are zeroed; shifts above max are clipped.
     tracking_interval : int
         Track every N timepoints (1 = every timepoint).
+    reference_update_interval : int
+        Re-anchor the per-position reference every N timepoints (0 = never,
+        i.e. keep the fixed t=0 reference). On a re-anchor timepoint the
+        current stack becomes the new reference and NO shift correction is
+        applied (the current stage position is accepted as the new baseline),
+        which avoids a jump. Useful for long timelapses where the sample
+        changes enough that phase-correlation against a stale reference
+        becomes unreliable.
     shift_estimation_channel : str
         Which representation to use for shift estimation:
         ``'raw'`` (default, no preprocessing), ``'phase'`` (phase
@@ -90,6 +98,7 @@ class DynaTrackConfig:
     dampening: tuple[float, float, float] | None = None
     shift_limits: dict[str, tuple[float, float]] | None = None
     tracking_interval: int = 1
+    reference_update_interval: int = 0
     shift_estimation_channel: str = "raw"
     preprocessing: list[str] | None = None
     deskew_config: dict[str, Any] | None = None
@@ -488,12 +497,20 @@ class DynaTrackUpdater(PositionUpdater):
             # No preprocessing: move the raw stack to the device directly.
             current_stack_zyx = torch.as_tensor(raw_stack, device=device, dtype=torch.float32)
 
-        # Store reference on first encounter
-        if position_index not in self._reference_stacks_zyx:
+        # (Re)anchor the reference: store it on first encounter, and re-anchor
+        # every ``reference_update_interval`` timepoints. On a re-anchor
+        # timepoint we adopt the current image as the new reference and apply
+        # NO correction (return position unchanged) -- the current stage
+        # position becomes the new baseline; correcting here would jump the
+        # stage against a reference we are about to discard.
+        interval = self._config.reference_update_interval
+        if (position_index not in self._reference_stacks_zyx) or (
+            interval and timepoint_index % interval == 0
+        ):
             self._reference_stacks_zyx[position_index] = current_stack_zyx
             ref_total = sum(a.nbytes for a in self._reference_stacks_zyx.values())
             logger.info(
-                f"DynaTrack: stored reference stack for p={position_index} "
+                f"DynaTrack: stored reference stack for p={position_index} from t={timepoint_index} "
                 f"(zyx_shape={current_stack_zyx.shape})"
             )
             logger.debug(

--- a/shrimpy/mantis/dynatrack.py
+++ b/shrimpy/mantis/dynatrack.py
@@ -392,6 +392,19 @@ class DynaTrackUpdater(PositionUpdater):
     def config(self) -> DynaTrackConfig:
         return self._config
 
+    def wants_reference_refresh(self, timepoint_index: int) -> bool:
+        """True on a scheduled re-anchor timepoint (see ``update``).
+
+        Mirrors the interval test in ``update``: when
+        ``reference_update_interval`` is set, every Nth timepoint adopts the
+        current stack as the new reference and applies no correction. The
+        manager uses this so a missing baseline suppresses only a correction,
+        never a due reference refresh. (First-encounter capture is not included
+        here -- it always has a baseline, so it never reaches this check.)
+        """
+        interval = self._config.reference_update_interval
+        return bool(interval) and timepoint_index % interval == 0
+
     def update(
         self,
         timepoint_index: int,

--- a/shrimpy/mantis/position_update.py
+++ b/shrimpy/mantis/position_update.py
@@ -151,6 +151,19 @@ class PositionUpdater:
         """
         return position
 
+    def wants_reference_refresh(self, timepoint_index: int) -> bool:
+        """Whether this updater will (re)anchor its reference at this timepoint.
+
+        The manager consults this only when no acquisition baseline was
+        recorded for a completed stack. A refresh timepoint applies no
+        correction -- the updater just adopts the current stack as the new
+        reference -- so a race-prone live-store value is harmless there and the
+        refresh should still run. A normal correction timepoint is skipped
+        instead, to avoid anchoring a shift to a store value a later update has
+        already moved on from.
+        """
+        return False
+
 
 class PositionUpdateManager:
     """Manages async position updates after each position is acquired.
@@ -303,18 +316,32 @@ class PositionUpdateManager:
             return
 
         # Baseline for the correction is the coords this stack was acquired at
-        # (recorded in apply_position_update). Fall back to the live store
-        # snapshot only when no baseline was recorded -- e.g. an event that
-        # never passed through apply_position_update.
+        # (recorded in apply_position_update).
         position = self._acquired_at.pop((timepoint_index, position_index), None)
         if position is None:
+            # No acquisition baseline was recorded for this stack.
+            if self.position_store.get_position(position_index) is None:
+                # Store doesn't track this position at all -> nothing to update.
+                return
+            if not self._updater.wants_reference_refresh(timepoint_index):
+                # A correction here would anchor the shift to a live-store value
+                # that the pre-fetch race may have advanced past where the stack
+                # was acquired -> overshoot. Skip; because shifts anchor to the
+                # current reference, the next timepoint re-centers fully.
+                logger.error(
+                    f"PosUpdateMgr: no acquisition baseline for p={position_index} "
+                    f"t={timepoint_index}; skipping this correction (next timepoint recovers)"
+                )
+                return
+            # Re-anchor timepoint: the updater applies no correction here -- it
+            # just adopts the current stack as the new reference and returns the
+            # position unchanged -- so the live-store value is harmless. Proceed
+            # so the scheduled reference refresh still happens without a baseline.
             logger.warning(
                 f"PosUpdateMgr: no acquisition baseline for p={position_index} "
-                f"t={timepoint_index}, falling back to live store (race-prone)"
+                f"t={timepoint_index}; proceeding for scheduled reference refresh"
             )
             position = self.position_store.get_position(position_index)
-        if position is None:
-            return
 
         data_gb = sum(a.nbytes for a in data) / 1024**3 if data else 0.0
         queue_depth = self._executor._work_queue.qsize()

--- a/shrimpy/tests/test_dynatrack.py
+++ b/shrimpy/tests/test_dynatrack.py
@@ -290,10 +290,37 @@ class TestDynaTrackUpdaterFlow:
         # Second call: detect shift
         result = updater.update(1, 0, pos, mov_frames)
 
-        expected_x = 100.0 + dx * scale_yx
-        expected_y = 200.0 + dy * scale_yx
+        # Correction is negative feedback: the stage moves OPPOSITE the
+        # measured image shift (updated = baseline - shift).
+        expected_x = 100.0 - dx * scale_yx
+        expected_y = 200.0 - dy * scale_yx
         assert result.x == pytest.approx(expected_x, abs=1e-6)
         assert result.y == pytest.approx(expected_y, abs=1e-6)
+
+    def test_reference_reanchor_skips_correction_and_updates_ref(self):
+        """With reference_update_interval=N, every Nth timepoint re-anchors the
+        reference to the current stack and applies NO correction."""
+        rng = np.random.default_rng(7)
+        updater = self._make_updater(reference_update_interval=2)
+        pos = PositionCoordinates(x=100.0, y=200.0, z=50.0)
+        ref = [rng.random((64, 64)) for _ in range(8)]
+        mov = [np.roll(f, 3, axis=1) for f in ref]  # shifted -> would correct
+
+        updater.update(0, 0, pos, ref)  # t=0: store reference
+        r1 = updater.update(1, 0, pos, mov)  # t=1: shifted -> correction applied
+        assert abs(r1.x - pos.x) > 1.0, "t=1 should produce a correction"
+
+        ref_before = updater._reference_stacks_zyx[0]
+        r2 = updater.update(2, 0, pos, mov)  # t=2: re-anchor timepoint
+        # No correction applied on the re-anchor timepoint.
+        assert (r2.x, r2.y, r2.z) == (pos.x, pos.y, pos.z)
+        # Reference replaced with the current (t=2) stack.
+        assert updater._reference_stacks_zyx[0] is not ref_before
+
+        # t=3 now compares against the new reference (same content) -> ~zero shift.
+        r3 = updater.update(3, 0, pos, mov)
+        assert r3.x == pytest.approx(pos.x, abs=1e-6)
+        assert r3.y == pytest.approx(pos.y, abs=1e-6)
 
     def test_no_data_returns_unchanged(self):
         """When data is None, position is returned unchanged."""
@@ -412,8 +439,9 @@ class TestPreprocessor:
         updater.update(0, 0, pos, frames)
         result = updater.update(1, 0, pos, frames)
 
-        # The preprocessor-introduced shift should be detected
-        assert result.y == pytest.approx(2.0, abs=1e-6)
+        # The preprocessor-introduced shift should be detected and corrected
+        # with negative feedback (stage moves opposite the +2 px image shift).
+        assert result.y == pytest.approx(-2.0, abs=1e-6)
 
 
 # ---------------------------------------------------------------------------

--- a/shrimpy/tests/test_position_update.py
+++ b/shrimpy/tests/test_position_update.py
@@ -203,6 +203,15 @@ class TestPositionUpdater:
 # ---------------------------------------------------------------------------
 
 
+def _record_baseline(manager, t, p):
+    """Simulate the event iterator recording the acquisition baseline for
+    (t, p) before the stack's frames complete. The real flow always does this
+    via ``apply_position_update``; without a baseline the manager now skips the
+    correction rather than anchoring it to a race-prone live-store value.
+    """
+    manager.apply_position_update(MDAEvent(index={"t": t, "p": p}))
+
+
 class TestPositionUpdateManager:
     def test_disabled_is_noop(self, disabled_config, position_store):
         manager = PositionUpdateManager(disabled_config, position_store)
@@ -224,6 +233,7 @@ class TestPositionUpdateManager:
 
         manager = PositionUpdateManager(enabled_config, position_store, updater=SpyUpdater())
         manager.start()
+        _record_baseline(manager, 0, 1)
         frames = [np.zeros((4, 4), dtype=np.uint16)]
         manager.on_position_complete(0, 1, data=frames)
         manager._pending_future.result(timeout=5)
@@ -246,6 +256,7 @@ class TestPositionUpdateManager:
 
         manager = PositionUpdateManager(enabled_config, position_store, updater=ShiftUpdater())
         manager.start()
+        _record_baseline(manager, 0, 0)
         manager.on_position_complete(0, 0)
         manager._pending_future.result(timeout=5)
         manager.shutdown()
@@ -266,6 +277,7 @@ class TestPositionUpdateManager:
             enabled_config, position_store, updater=FailingUpdater()
         )
         manager.start()
+        _record_baseline(manager, 0, 0)
         manager.on_position_complete(0, 0)
         manager._pending_future.result(timeout=5)
         manager.shutdown()
@@ -286,6 +298,7 @@ class TestPositionUpdateManager:
 
         manager = PositionUpdateManager(enabled_config, position_store, updater=SlowUpdater())
         manager.start()
+        _record_baseline(manager, 0, 0)
         manager.on_position_complete(0, 0)
         manager.shutdown()
         assert completed.is_set()
@@ -358,11 +371,11 @@ class TestPositionUpdateManager:
         assert seen["position"].y == 200.0
         assert seen["position"].z == 50.0
 
-    def test_updater_falls_back_to_store_without_baseline(
-        self, enabled_config, position_store
-    ):
+    def test_no_baseline_skips_correction(self, enabled_config, position_store):
         """When no acquisition baseline was recorded (event never passed
-        through apply_position_update), fall back to the live store snapshot.
+        through apply_position_update), the correction is skipped rather than
+        anchored to a race-prone live-store value. Because shifts anchor to a
+        fixed reference, the next timepoint re-centers, so skipping is safe.
         """
         seen = {}
 
@@ -375,12 +388,41 @@ class TestPositionUpdateManager:
         manager.start()
         # No apply_position_update call -> no baseline recorded for (0, 0).
         manager.on_position_complete(0, 0)
-        manager._pending_future.result(timeout=5)
+        # Nothing is submitted and the updater is never called.
+        assert manager._pending_future is None
+        assert "position" not in seen
         manager.shutdown()
 
+    def test_no_baseline_proceeds_on_reference_refresh(self, enabled_config, position_store):
+        """A missing baseline skips only a *correction*, not a scheduled
+        reference refresh. When the updater reports this is a refresh timepoint
+        (wants_reference_refresh -> True), the update still runs: the refresh
+        applies no correction, so the live-store snapshot is a harmless baseline
+        and the reference must still be re-anchored.
+        """
+        seen = {}
+
+        class RefreshUpdater(PositionUpdater):
+            def wants_reference_refresh(self, timepoint_index):
+                return True
+
+            def update(self, t_idx, p_idx, position, data=None):
+                seen["position"] = position
+                return position
+
+        manager = PositionUpdateManager(
+            enabled_config, position_store, updater=RefreshUpdater()
+        )
+        manager.start()
+        # No apply_position_update call -> no baseline recorded for (0, 0), but
+        # this is a refresh timepoint, so the updater must still run.
+        manager.on_position_complete(0, 0)
+        assert manager._pending_future is not None
+        manager._pending_future.result(timeout=5)
+        manager.shutdown()
+        # Proceeded using the live-store snapshot as the baseline.
         assert seen["position"].x == 100.0
         assert seen["position"].y == 200.0
-        assert seen["position"].z == 50.0
 
 
 # ---------------------------------------------------------------------------
@@ -430,6 +472,7 @@ class TestMantisEnginePositionUpdate:
         store.update_position(0, x=10.0, y=20.0, z=5.0)
         manager = PositionUpdateManager(PositionUpdateConfig(enabled=True), store)
         manager.start()
+        _record_baseline(manager, 0, 0)
         engine._position_update_manager = manager
         engine._position_update_frames = {}
         engine._position_update_expected_slices = 3
@@ -466,6 +509,7 @@ class TestMantisEnginePositionUpdate:
             PositionUpdateConfig(enabled=True), store, updater=SpyUpdater()
         )
         manager.start()
+        _record_baseline(manager, 0, 0)
         engine._position_update_manager = manager
         engine._position_update_frames = {}
         engine._position_update_expected_slices = 2
@@ -488,6 +532,8 @@ class TestMantisEnginePositionUpdate:
         store.update_position(1, x=30.0, y=40.0, z=15.0)
         manager = PositionUpdateManager(PositionUpdateConfig(enabled=True), store)
         manager.start()
+        _record_baseline(manager, 0, 0)
+        _record_baseline(manager, 0, 1)
         engine._position_update_manager = manager
         engine._position_update_frames = {}
         engine._position_update_expected_slices = 2
@@ -686,15 +732,19 @@ class TestBackpressure:
         for t in range(3):
             for p in range(3):
                 for z in range(2):
-                    events.append(MDAEvent(
-                        index={"t": t, "p": p, "c": 0, "z": z},
-                        x_pos=float(p * 100),
-                        y_pos=float(p * 100),
-                    ))
+                    events.append(
+                        MDAEvent(
+                            index={"t": t, "p": p, "c": 0, "z": z},
+                            x_pos=float(p * 100),
+                            y_pos=float(p * 100),
+                        )
+                    )
 
         frame = np.zeros((64, 64), dtype=np.uint16)
 
-        with patch("shrimpy.mantis.mantis_engine.MDAEngine.event_iterator", return_value=iter(events)):
+        with patch(
+            "shrimpy.mantis.mantis_engine.MDAEngine.event_iterator", return_value=iter(events)
+        ):
             for event in engine.event_iterator(events):
                 t_idx = event.index.get("t", 0)
                 p_idx = event.index.get("p", 0)
@@ -754,7 +804,9 @@ class TestBackpressure:
                 pending_at_submit.append(0)
             return orig_on_position_complete(self_mgr, t_idx, p_idx, data)
 
-        manager.on_position_complete = lambda t, p, data=None: tracking_on_position_complete(manager, t, p, data)
+        manager.on_position_complete = lambda t, p, data=None: tracking_on_position_complete(
+            manager, t, p, data
+        )
 
         engine._position_update_manager = manager
         engine._position_update_frames = {}
@@ -764,15 +816,19 @@ class TestBackpressure:
         events = []
         for t in range(4):
             for p in range(3):
-                events.append(MDAEvent(
-                    index={"t": t, "p": p, "c": 0, "z": 0},
-                    x_pos=float(p * 100),
-                    y_pos=float(p * 100),
-                ))
+                events.append(
+                    MDAEvent(
+                        index={"t": t, "p": p, "c": 0, "z": 0},
+                        x_pos=float(p * 100),
+                        y_pos=float(p * 100),
+                    )
+                )
 
         frame = np.zeros((64, 64), dtype=np.uint16)
 
-        with patch("shrimpy.mantis.mantis_engine.MDAEngine.event_iterator", return_value=iter(events)):
+        with patch(
+            "shrimpy.mantis.mantis_engine.MDAEngine.event_iterator", return_value=iter(events)
+        ):
             for event in engine.event_iterator(events):
                 engine._on_frame_ready(frame, event)
 


### PR DESCRIPTION
Closes #270. Sub-PR of #267. Stacks on #285 (PR-3).

Sub-PR 4/6.

## Summary

Add `reference_update_interval` (default 0 = never). On a re-anchor timepoint the current stack becomes the new reference and **no** shift correction is applied — the current stage position is accepted as the new baseline, avoiding a jump.

## Motivation

Validated on-microscope: a fixed t=0 reference saturates over a 15 h run (sample develops, phase-correlation against the stale reference returns large/clipped/oscillating shifts). A 1 h test with `reference_update_interval=4` keeps the reference fresh: max shift 3.4 µm, no clipping, 0 timeouts/OOM.

## Test plan

- [x] Unit tests for re-anchor behavior (in ad37858).
- [x] No new test regressions vs PR-3 baseline; PR-4 has 0 failures (down from 2 on PR-3) — ad37858's test-file updates resolve the residual stale assertions.
- [x] On-microscope: 1 h run with `reference_update_interval=4` validated.

## Commits

Cherry-picked from #273 (preserving original authorship):
- DynaTrack: periodic reference re-anchor for long timelapses