### PR TITLE
DynaTrack: support fluorescence (deskew-only) tracking channels

### DIFF
--- a/config/mda/mantis/dynatrack_demo.yaml
+++ b/config/mda/mantis/dynatrack_demo.yaml
@@ -35,6 +35,15 @@ channels:
   z_offset: 0.0
   acquire_every: 1
   camera: null
+# For deskewed-GFP (fluorescence) tracking, add a fluorescence channel as
+# index 1 and point `update_channel: 1` at it (see position_update below):
+# - config: GFP
+#   group: Channel
+#   exposure: 10.0
+#   do_stack: true
+#   z_offset: 0.0
+#   acquire_every: 1
+#   camera: null
 
 # Define axis order
 axis_order:
@@ -59,6 +68,8 @@ metadata:
       stage: ObjectiveZ
     position_update:
       enabled: true
+      # Channel index fed to the tracker (0 = first channel, BF here).
+      # For deskewed-GFP tracking set this to the GFP channel index (e.g. 1).
       update_channel: 0
       z_device: ObjectiveZ
       dynatrack:
@@ -77,8 +88,9 @@ metadata:
         #   x: [2.0, 10.0]
 
         # Preprocessing pipeline: deskew -> phase recon -> virtual staining
-        # Options: ['deskew', 'phase', 'vs'], ['deskew', 'phase'], ['phase', 'vs'], ['phase']
+        # Options: ['deskew','phase','vs'], ['deskew','phase'], ['phase','vs'], ['phase'], ['deskew']
         preprocessing: ['deskew', 'phase', 'vs']
+        # preprocessing: ['deskew']   # deskewed-GFP (fluorescence) tracking: deskew only
         # preprocessing: ['phase']
 
         # Biahub deskew parameters for light-sheet data
@@ -96,9 +108,11 @@ metadata:
           scan_step_um: 0.15
           keep_overhang: false
           average_n_slices: 3
-        # Which channel to use for shift estimation:
-        # 'raw', 'phase', 'vs_nuclei', 'vs_membrane'
+        # Which representation to use for shift estimation:
+        # 'deskewed' (deskew-only output, e.g. deskewed GFP), 'phase',
+        # 'vs_nuclei', 'vs_membrane'
         shift_estimation_channel: 'vs_nuclei'
+        # shift_estimation_channel: 'deskewed'   # deskewed-GFP (fluorescence) tracking
         # shift_estimation_channel: 'phase'
 
         # Waveorder phase reconstruction parameters

--- a/shrimpy/mantis/dynatrack.py
+++ b/shrimpy/mantis/dynatrack.py
@@ -72,9 +72,9 @@ class DynaTrackConfig:
         becomes unreliable.
     shift_estimation_channel : str
         Which representation to use for shift estimation:
-        ``'raw'`` (default, no preprocessing), ``'phase'`` (phase
-        reconstruction), ``'vs_nuclei'`` or ``'vs_membrane'`` (virtual
-        staining).
+        ``'deskewed'`` (default; the deskewed input volume, e.g. deskew-only
+        tracking), ``'phase'`` (phase reconstruction), ``'vs_nuclei'`` or
+        ``'vs_membrane'`` (virtual staining).
     preprocessing : list[str] | None
         Pipeline steps, e.g. ``['phase']`` or ``['phase', 'vs']``.
         Used by external factory functions to build the preprocessor callable.
@@ -99,7 +99,7 @@ class DynaTrackConfig:
     shift_limits: dict[str, tuple[float, float]] | None = None
     tracking_interval: int = 1
     reference_update_interval: int = 0
-    shift_estimation_channel: str = "raw"
+    shift_estimation_channel: str = "deskewed"
     preprocessing: list[str] | None = None
     deskew_config: dict[str, Any] | None = None
     phase_config: dict[str, Any] | None = None
@@ -693,8 +693,11 @@ class DynaTrackUpdater(PositionUpdater):
                 channel_names,
             )
 
-        # Create position on first encounter
-        pos_name = self._debug_position_names.get(position_index, f"p{position_index}")
+        # Create position on first encounter. OME-Zarr (iohub) requires
+        # alphanumeric path names, so strip non-alphanumeric characters from
+        # the acquisition position name (e.g. "1-Pos0000" -> "1Pos0000").
+        raw_name = self._debug_position_names.get(position_index, f"p{position_index}")
+        pos_name = "".join(ch for ch in raw_name if ch.isalnum()) or f"p{position_index}"
         pos_key = f"0/{position_index}/{pos_name}"
         if pos_key not in dict(self._debug_store.positions()):
             pos = self._debug_store.create_position("0", str(position_index), pos_name)

--- a/shrimpy/mantis/dynatrack_preprocessing.py
+++ b/shrimpy/mantis/dynatrack_preprocessing.py
@@ -77,7 +77,11 @@ def build_preprocessor(
     pipeline = config.preprocessing
     channel = config.shift_estimation_channel
 
-    if not pipeline or channel == "raw":
+    # No pipeline -> no preprocessor (track on the raw, un-deskewed stack).
+    # Deskew-only tracking is expressed as preprocessing=['deskew'] +
+    # shift_estimation_channel='deskewed' (the deskewed volume is emitted
+    # under the "deskewed" key by the preprocessor).
+    if not pipeline:
         return None
 
     if "phase" not in pipeline and "deskew" not in pipeline:
@@ -236,9 +240,9 @@ class _LabelfreePreprocessor:
             vs_result = self._predict_vs(volume_phase)
             channels.update(vs_result)
 
-        # If no phase or VS, return the (possibly deskewed) raw volume
+        # No phase/VS channel -> emit the (deskewed) input volume itself.
         if not channels:
-            channels["raw"] = volume
+            channels["deskewed"] = volume
 
         self._log_gpu_memory()
         return channels

--- a/shrimpy/tests/test_dynatrack.py
+++ b/shrimpy/tests/test_dynatrack.py
@@ -143,7 +143,7 @@ class TestDynaTrackConfig:
         assert cfg.dampening is None
         assert cfg.shift_limits is None
         assert cfg.tracking_interval == 1
-        assert cfg.shift_estimation_channel == "raw"
+        assert cfg.shift_estimation_channel == "deskewed"
         assert cfg.preprocessing is None
         assert cfg.shift_log_path is None
 
@@ -404,7 +404,7 @@ class TestPreprocessor:
 
         def identity_preprocessor(stack: np.ndarray) -> dict[str, torch.Tensor]:
             call_count[0] += 1
-            return {"raw": torch.as_tensor(stack)}
+            return {"deskewed": torch.as_tensor(stack)}
 
         updater = DynaTrackUpdater(config=config, preprocessor=identity_preprocessor)
         pos = PositionCoordinates(x=100.0, y=200.0, z=50.0)
@@ -429,8 +429,8 @@ class TestPreprocessor:
         def shifting_preprocessor(stack: np.ndarray) -> dict[str, torch.Tensor]:
             if first_call[0]:
                 first_call[0] = False
-                return {"raw": torch.as_tensor(stack)}
-            return {"raw": torch.as_tensor(np.roll(stack, 2, axis=1))}
+                return {"deskewed": torch.as_tensor(stack)}
+            return {"deskewed": torch.as_tensor(np.roll(stack, 2, axis=1))}
 
         updater = DynaTrackUpdater(config=config, preprocessor=shifting_preprocessor)
         pos = PositionCoordinates(x=0.0, y=0.0, z=0.0)


### PR DESCRIPTION
Closes #282. Sub-PR of #267. Stacks on #286 (PR-4).

Sub-PR 5/6.

## Summary

Allow tracking on a raw fluorescence channel (e.g. GFP) with `deskew` as the only preprocessing step — no phase reconstruction or virtual staining required.

- Rename the image-volume channel `raw` → `deskewed` (it holds the deskewed input; old name was misleading).
- Sanitize position names to alphanumeric in `_save_debug_channels` so hyphenated names like `1-Pos0000` no longer crash the OME-Zarr debug save.
- Updated demo MDA + `dynatrack_demo.yaml` documenting the deskewed-GFP setup.

## Test plan

- [x] No new test regressions vs PR-4 baseline.
- [x] On-microscope: 1 h GFP deskew-only run — coherent PCC peaks, 0 errors, debug volumes save cleanly.

## Commits

Cherry-picked from #273 (preserving original authorship):
- DynaTrack: support fluorescence (deskew-only) tracking channels