### PR TITLE
DynaTrack: multi-Otsu center-of-mass & referenceless ROI tracking

### DIFF
--- a/config/mda/mantis/dynatrack_demo.yaml
+++ b/config/mda/mantis/dynatrack_demo.yaml
@@ -76,6 +76,16 @@ metadata:
         scale_yx: 0.1494
         scale_z: 0.174
         tracking_interval: 1
+        # Shift-estimation algorithm: 'pcc' (phase cross-correlation),
+        # 'multiotsu_center_of_mass' (multi-Otsu threshold -> centroid), or
+        # 'multiotsu_pcc' (multi-Otsu threshold -> PCC on the binary masks).
+        # Note: center-of-mass uses the reference only as a fixed target
+        # centroid, so it does NOT need re-anchoring (set reference_update_interval: 0).
+        tracking_method: 'pcc'
+        # tracking_method: 'multiotsu_center_of_mass'
+        # tracking_method: 'multiotsu_pcc'
+        otsu_sigma: 5.0       # Gaussian blur sigma before thresholding (multi-Otsu methods)
+        otsu_component: 1     # which multi-Otsu threshold: 0 = lower, 1 = upper (brightest); use 0 for gfp and 1 for bf
         # Re-anchor the reference every N timepoints (0 = never; keep the fixed
         # t=0 reference). On a re-anchor timepoint the current stack becomes the
         # new reference and no correction is applied. Use for long timelapses

--- a/config/mda/mantis/dynatrack_demo.yaml
+++ b/config/mda/mantis/dynatrack_demo.yaml
@@ -77,15 +77,25 @@ metadata:
         scale_z: 0.174
         tracking_interval: 1
         # Shift-estimation algorithm: 'pcc' (phase cross-correlation),
+        # 'intensity_center_of_mass' (intensity-weighted centroid vs ROI centre
+        #   in deskew space; no threshold, no reference stack),
+        # 'roi_center_pcc' (cross-correlate against a Gaussian blob centred on
+        #   the ROI centre in deskew space; no reference stack),
         # 'multiotsu_center_of_mass' (multi-Otsu threshold -> centroid), or
         # 'multiotsu_pcc' (multi-Otsu threshold -> PCC on the binary masks).
         # Note: center-of-mass uses the reference only as a fixed target
         # centroid, so it does NOT need re-anchoring (set reference_update_interval: 0).
+        # The ROI-centre methods ('intensity_center_of_mass', 'roi_center_pcc')
+        # are referenceless and correct from the first timepoint.
         tracking_method: 'pcc'
+        # tracking_method: 'intensity_center_of_mass'
+        # tracking_method: 'roi_center_pcc'
         # tracking_method: 'multiotsu_center_of_mass'
         # tracking_method: 'multiotsu_pcc'
         otsu_sigma: 5.0       # Gaussian blur sigma before thresholding (multi-Otsu methods)
         otsu_component: 1     # which multi-Otsu threshold: 0 = lower, 1 = upper (brightest); use 0 for gfp and 1 for bf
+        roi_blob_sigma: 10.0  # Gaussian blob sigma (px) for the 'roi_center_pcc' template; ~structure radius
+        # roi_background_percentile: 80   # 'intensity_center_of_mass': subtract this intensity percentile (0-100) as a background floor before weighting; null = raw
         # Re-anchor the reference every N timepoints (0 = never; keep the fixed
         # t=0 reference). On a re-anchor timepoint the current stack becomes the
         # new reference and no correction is applied. Use for long timelapses

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
 ]
 dynatrack = [
   "biahub",
+  "matplotlib",
   "torch",
   "viscy",
   "waveorder==3.0.2",

--- a/shrimpy/mantis/dynatrack.py
+++ b/shrimpy/mantis/dynatrack.py
@@ -540,8 +540,16 @@ def _intensity_center_of_mass(img: torch.Tensor, background: float = 0.0) -> tor
     weights = (img.to(dtype=torch.float32) - background).clamp_min(0)
     total = weights.sum()
     if total <= 0:
+        # No positive mass (blank or fully sub-background volume): the centroid
+        # is undefined. Fall back to the geometric centre so a ROI-centre shift
+        # is zero, rather than reporting the origin -- which would command a
+        # spurious half-volume jump toward the corner.
         del weights
-        return torch.zeros(img.ndim, device=img.device)
+        return torch.tensor(
+            [(s - 1) / 2.0 for s in img.shape],
+            device=img.device,
+            dtype=torch.float32,
+        )
 
     centers = []
     for axis in range(weights.ndim):
@@ -849,6 +857,14 @@ class DynaTrackUpdater(PositionUpdater):
         preprocessor: Callable[[np.ndarray], dict[str, torch.Tensor]] | None = None,
     ) -> None:
         self._config = config
+        if config.reference_update_interval and config.tracking_method in _ROI_CENTER_METHODS:
+            logger.warning(
+                "DynaTrack: reference_update_interval=%d is ignored for referenceless "
+                "tracking_method=%r (no reference stack to re-anchor); the ROI centre "
+                "is the fixed target on every timepoint.",
+                config.reference_update_interval,
+                config.tracking_method,
+            )
         self._preprocessor = preprocessor
         self._reference_stacks_zyx: dict[int, torch.Tensor] = {}
         self._shift_log_path: Path | None = (
@@ -862,6 +878,26 @@ class DynaTrackUpdater(PositionUpdater):
     @property
     def config(self) -> DynaTrackConfig:
         return self._config
+
+    def wants_reference_refresh(self, timepoint_index: int) -> bool:
+        """True on a scheduled re-anchor timepoint (see ``update``).
+
+        The manager consults this when no acquisition baseline was recorded:
+        a re-anchor timepoint applies NO correction (it just adopts the current
+        stack as the new reference), so a race-prone live-store value is
+        harmless and the refresh should still run; a normal correction timepoint
+        is skipped instead. Mirrors the interval test in ``update``.
+
+        Referenceless methods (``_ROI_CENTER_METHODS``) keep no reference and
+        apply a correction on *every* timepoint, so they never want a refresh --
+        return False regardless of ``reference_update_interval``, otherwise the
+        manager would let a real ROI-centre correction run against an unanchored
+        (race-prone) baseline.
+        """
+        if self._config.tracking_method in _ROI_CENTER_METHODS:
+            return False
+        interval = self._config.reference_update_interval
+        return bool(interval) and timepoint_index % interval == 0
 
     def update(
         self,

--- a/shrimpy/mantis/dynatrack.py
+++ b/shrimpy/mantis/dynatrack.py
@@ -62,6 +62,15 @@ class DynaTrackConfig:
         "y", "x". Shifts below min are zeroed; shifts above max are clipped.
     tracking_interval : int
         Track every N timepoints (1 = every timepoint).
+    tracking_method : str
+        Shift estimation algorithm. One of ``'pcc'`` (phase cross-correlation,
+        default), ``'multiotsu_center_of_mass'`` (multi-Otsu threshold then
+        area-weighted centroid), or ``'multiotsu_pcc'`` (multi-Otsu threshold
+        then PCC on the binary masks).
+    otsu_sigma : float
+        Gaussian blur sigma for the multi-Otsu methods (default 5.0).
+    otsu_component : int
+        Which multi-Otsu threshold to use: 0 = lower, 1 = upper (default 0).
     reference_update_interval : int
         Re-anchor the per-position reference every N timepoints (0 = never,
         i.e. keep the fixed t=0 reference). On a re-anchor timepoint the
@@ -98,6 +107,9 @@ class DynaTrackConfig:
     dampening: tuple[float, float, float] | None = None
     shift_limits: dict[str, tuple[float, float]] | None = None
     tracking_interval: int = 1
+    tracking_method: str = "pcc"
+    otsu_sigma: float = 5.0
+    otsu_component: int = 0
     reference_update_interval: int = 0
     shift_estimation_channel: str = "deskewed"
     preprocessing: list[str] | None = None
@@ -245,6 +257,255 @@ def _phase_cross_corr(
     logger.debug("phase cross corr: peak at %s (device=%s)", peak, device)
 
     return peak
+
+
+# ---------------------------------------------------------------------------
+# Multi-Otsu thresholding helpers (GPU)
+# ---------------------------------------------------------------------------
+
+
+def _gaussian_blur_3d(img: torch.Tensor, sigma: float) -> torch.Tensor:
+    """Apply separable 3-D Gaussian blur entirely on *img*'s device.
+
+    Uses three sequential 1-D convolutions (one per axis) with reflect
+    padding, matching the behaviour of ``skimage.filters.gaussian``.
+    """
+    import torch
+    import torch.nn.functional as F  # noqa: N812
+
+    if sigma <= 0:
+        return img
+
+    max_radius = int(4 * sigma + 0.5)
+
+    vol = img[None, None]  # (1, 1, Z, Y, X)
+
+    # Convolve each spatial axis with a 1-D Gaussian kernel.
+    # Reflect padding requires pad < dim, so clamp per axis.
+    for spatial_idx, axis in enumerate((2, 3, 4)):
+        r = min(max_radius, vol.shape[axis] - 1)
+        x = torch.arange(-r, r + 1, device=img.device, dtype=img.dtype)
+        k1d = torch.exp(-0.5 * (x / sigma) ** 2)
+        k1d = k1d / k1d.sum()
+
+        # F.pad expects (x_l, x_r, y_l, y_r, z_l, z_r) — last dim first.
+        # spatial_idx: 0=Z(axis2), 1=Y(axis3), 2=X(axis4)
+        pad = [0] * 6
+        pad_pos = 2 * (2 - spatial_idx)  # Z→4, Y→2, X→0
+        pad[pad_pos] = r
+        pad[pad_pos + 1] = r
+        vol = F.pad(vol, pad, mode="reflect")
+
+        k_shape = [1, 1, 1, 1, 1]
+        k_shape[axis] = len(k1d)
+        vol = F.conv3d(vol, k1d.reshape(k_shape))
+
+    return vol[0, 0]
+
+
+def _multiotsu_threshold(
+    img_blur: torch.Tensor,
+    otsu_component: int = 0,
+    nbins: int = 256,
+) -> float:
+    """Compute multi-Otsu threshold entirely on GPU.
+
+    Builds a histogram with ``torch.histc``, then finds the two
+    thresholds that maximise inter-class variance (3-class Otsu) via a
+    fully vectorised search over all bin-pair splits — all on the
+    tensor's device.
+
+    Parameters
+    ----------
+    img_blur : torch.Tensor
+        Pre-blurred volume on GPU.
+    otsu_component : int
+        Which threshold to return (0 = lower, 1 = upper).
+    nbins : int
+        Number of histogram bins.
+
+    Returns
+    -------
+    float
+        The selected threshold value.
+    """
+    import torch
+
+    vmin = img_blur.min()
+    vmax = img_blur.max()
+    if vmin == vmax:
+        return float(vmin)
+
+    hist = torch.histc(img_blur, bins=nbins, min=float(vmin), max=float(vmax))
+    hist = hist / hist.sum()  # normalise to probability
+
+    bin_centers = torch.linspace(float(vmin), float(vmax), nbins, device=img_blur.device)
+
+    # Cumulative sums for fast inter-class variance computation
+    cum_w = torch.cumsum(hist, dim=0)  # cumulative weight
+    cum_wm = torch.cumsum(hist * bin_centers, dim=0)  # cumulative weighted mean
+    total_mean = cum_wm[-1]
+    del hist
+
+    # 3-class Otsu: choose split boundaries a < b (bin indices) that maximise
+    # the between-class variance, evaluated over all (a, b) pairs at once
+    # instead of a Python double loop (this is the expensive part).
+    #   class 0 = bins [0..a]   class 1 = bins [a+1..b]   class 2 = bins [b+1..]
+    eps = 1e-10
+    w0 = cum_w.unsqueeze(1)  # [N, 1]  weight of class 0 (boundary a)
+    w1 = cum_w.unsqueeze(0) - cum_w.unsqueeze(1)  # [N, N]  class 1 (a < b)
+    w2 = 1.0 - cum_w.unsqueeze(0)  # [1, N]  class 2 (boundary b)
+    m0 = cum_wm.unsqueeze(1) / w0.clamp_min(eps)
+    m1 = (cum_wm.unsqueeze(0) - cum_wm.unsqueeze(1)) / w1.clamp_min(eps)
+    m2 = (total_mean - cum_wm.unsqueeze(0)) / w2.clamp_min(eps)
+    sigma = (
+        w0 * (m0 - total_mean) ** 2 + w1 * (m1 - total_mean) ** 2 + w2 * (m2 - total_mean) ** 2
+    )
+
+    bins = torch.arange(nbins, device=img_blur.device)
+    valid = (
+        (bins.unsqueeze(0) > bins.unsqueeze(1))  # b > a
+        & (bins.unsqueeze(0) <= nbins - 2)  # class 2 non-empty
+        & (w0 > eps)
+        & (w1 > eps)
+        & (w2 > eps)
+    )
+    sigma = sigma.masked_fill(~valid, -1.0)
+
+    flat = int(torch.argmax(sigma))
+    best_a, best_b = divmod(flat, nbins)
+    # the original loop indexed thresholds at t1 = a + 1, t2 = b + 1
+    thresholds = (float(bin_centers[best_a + 1]), float(bin_centers[best_b + 1]))
+    del cum_w, cum_wm, bin_centers, sigma
+    logger.debug("multi-Otsu thresholds: %s (using component %d)", thresholds, otsu_component)
+    idx = min(otsu_component, 1)
+    return thresholds[idx]
+
+
+def _binary_mask(
+    img: torch.Tensor,
+    sigma: float = 5.0,
+    otsu_component: int = 0,
+) -> torch.Tensor:
+    """Rescale, blur, and threshold a 3-D volume on GPU.
+
+    Parameters
+    ----------
+    img : torch.Tensor
+        Input volume (Z, Y, X) on the target device.
+    sigma : float
+        Gaussian blur sigma applied before thresholding.
+    otsu_component : int
+        Which multi-Otsu threshold to use (0 = lower, 1 = upper).
+
+    Returns
+    -------
+    torch.Tensor
+        Boolean mask on the same device as *img*.
+    """
+    import torch
+
+    img = img.to(dtype=torch.float32)
+
+    # Rescale to [0, 1]
+    vmin = img.min()
+    vmax = img.max()
+    if vmax > vmin:
+        img = (img - vmin) / (vmax - vmin)
+    else:
+        return torch.zeros_like(img, dtype=torch.bool)
+
+    img_blur = _gaussian_blur_3d(img, sigma)
+    del img
+    threshold = _multiotsu_threshold(img_blur, otsu_component)
+    mask = img_blur > threshold
+    del img_blur
+    return mask
+
+
+def _center_of_mass(mask: torch.Tensor) -> torch.Tensor:
+    """Compute the center of mass of a boolean mask on GPU.
+
+    Equivalent to the area-weighted centroid: every True voxel
+    contributes equally, so larger connected regions naturally
+    dominate.
+
+    Parameters
+    ----------
+    mask : torch.Tensor
+        Boolean mask (Z, Y, X).
+
+    Returns
+    -------
+    torch.Tensor
+        Center-of-mass coordinates, shape ``(ndim,)``, on the same device.
+    """
+    import torch
+
+    coords = torch.nonzero(mask, as_tuple=False).to(dtype=torch.float32)
+    if coords.shape[0] == 0:
+        return torch.zeros(mask.ndim, device=mask.device)
+    center = coords.mean(dim=0)
+    del coords
+    return center
+
+
+def _multiotsu_center_of_mass(
+    ref_img: torch.Tensor,
+    mov_img: torch.Tensor,
+    sigma: float = 5.0,
+    otsu_component: int = 0,
+) -> tuple[float, ...]:
+    """Compute shift via multi-Otsu thresholding + center of mass on GPU.
+
+    Both images are thresholded independently and the shift is the
+    difference between their centres of mass (ZYX pixel order).
+    All heavy computation stays on the input tensor's device.
+    """
+    ref_mask = _binary_mask(ref_img, sigma=sigma, otsu_component=otsu_component)
+    mov_mask = _binary_mask(mov_img, sigma=sigma, otsu_component=otsu_component)
+
+    ref_center = _center_of_mass(ref_mask)
+    del ref_mask
+    mov_center = _center_of_mass(mov_mask)
+    del mov_mask
+
+    shift_zyx = mov_center - ref_center
+    logger.debug(
+        "multiotsu_center_of_mass: ref_center=%s mov_center=%s shift=%s",
+        ref_center.tolist(),
+        mov_center.tolist(),
+        shift_zyx.tolist(),
+    )
+    del ref_center, mov_center
+    return tuple(float(s) for s in shift_zyx)
+
+
+def _multiotsu_pcc(
+    ref_img: torch.Tensor,
+    mov_img: torch.Tensor,
+    sigma: float = 5.0,
+    otsu_component: int = 0,
+    maximum_shift: float = 1.0,
+) -> tuple[int, ...]:
+    """Compute shift via multi-Otsu thresholding + PCC on binary masks.
+
+    Both images are thresholded on GPU, then phase cross-correlation
+    is run on the binary volumes entirely on device.
+    """
+    import torch
+
+    ref_mask = _binary_mask(ref_img, sigma=sigma, otsu_component=otsu_component)
+    mov_mask = _binary_mask(mov_img, sigma=sigma, otsu_component=otsu_component)
+
+    ref_binary_f = ref_mask.to(dtype=torch.float32)
+    del ref_mask
+    mov_binary_f = mov_mask.to(dtype=torch.float32)
+    del mov_mask
+
+    result = _phase_cross_corr(ref_binary_f, mov_binary_f, maximum_shift)
+    del ref_binary_f, mov_binary_f
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -466,7 +727,6 @@ class DynaTrackUpdater(PositionUpdater):
                 f"DynaTrack[mem]: after preprocessor p={position_index} t={timepoint_index} "
                 f"rss={_rss_gb():.2f} GB channels_total={ch_bytes / 1024**3:.2f} GB"
             )
-            self._save_debug_channels(channels_zyx, timepoint_index, position_index)
             # Select the configured channel for shift estimation. Stays as a
             # torch tensor on device; PCC consumes tensors directly.
             channel_name = self._config.shift_estimation_channel
@@ -478,6 +738,15 @@ class DynaTrackUpdater(PositionUpdater):
                     f"output {list(channels_zyx.keys())}, using first channel"
                 )
                 selected = next(iter(channels_zyx.values()))
+            self._save_debug_channels(channels_zyx, timepoint_index, position_index)
+            # For center-of-mass tracking, save a PNG of the thresholded mask
+            # (Z max-projection) with the computed centroid marked, for a quick
+            # visual check of where the tracker is centring.
+            if (
+                self._debug_zarr_path is not None
+                and self._config.tracking_method == "multiotsu_center_of_mass"
+            ):
+                self._save_center_png(selected, timepoint_index, position_index)
             # Clone into a compact standalone tensor. A bare ``.detach()`` is a
             # view that keeps the *entire* preprocessor output alive (all
             # channels share one parent tensor), so a stored reference would
@@ -623,8 +892,30 @@ class DynaTrackUpdater(PositionUpdater):
         """
         cfg = self._config
 
-        # 1. Phase cross-correlation in pixel space (returns ZYX order)
-        shifts_zyx_px = _phase_cross_corr(reference_zyx, current_zyx, cfg.maximum_shift)
+        # 1. Compute pixel shifts using the configured method (returns ZYX order)
+        method = cfg.tracking_method
+        if method == "pcc":
+            shifts_zyx_px = _phase_cross_corr(reference_zyx, current_zyx, cfg.maximum_shift)
+        elif method == "multiotsu_center_of_mass":
+            shifts_zyx_px = _multiotsu_center_of_mass(
+                reference_zyx,
+                current_zyx,
+                sigma=cfg.otsu_sigma,
+                otsu_component=cfg.otsu_component,
+            )
+        elif method == "multiotsu_pcc":
+            shifts_zyx_px = _multiotsu_pcc(
+                reference_zyx,
+                current_zyx,
+                sigma=cfg.otsu_sigma,
+                otsu_component=cfg.otsu_component,
+                maximum_shift=cfg.maximum_shift,
+            )
+        else:
+            raise ValueError(
+                f"Unknown tracking_method={method!r}. "
+                "Use 'pcc', 'multiotsu_center_of_mass', or 'multiotsu_pcc'."
+            )
 
         # 2. Convert pixels to microns
         shifts_zyx_um = np.array(
@@ -718,3 +1009,45 @@ class DynaTrackUpdater(PositionUpdater):
             pos_name,
             pos_node["0"].shape,
         )
+
+    def _save_center_png(
+        self,
+        volume: torch.Tensor,
+        timepoint_index: int,
+        position_index: int,
+    ) -> None:
+        """Save a PNG of the thresholded mask (Z max-projection) with the
+        center-of-mass marked, for a quick visual check of the tracker's
+        centring. Written to a ``dynatrack_centers/`` folder next to the
+        debug zarr, one PNG per position per timepoint.
+        """
+        if self._debug_zarr_path is None:
+            return
+
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+        mask = _binary_mask(
+            volume,
+            sigma=self._config.otsu_sigma,
+            otsu_component=self._config.otsu_component,
+        )
+        cz, cy, cx = (float(c) for c in _center_of_mass(mask).tolist())
+        mip = mask.any(dim=0).detach().cpu().numpy()  # (Y, X) projection over Z
+
+        raw_name = self._debug_position_names.get(position_index, f"p{position_index}")
+        pos_name = "".join(ch for ch in raw_name if ch.isalnum()) or f"p{position_index}"
+        out_dir = self._debug_zarr_path.with_name("dynatrack_centers")
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_path = out_dir / f"{pos_name}_t{timepoint_index:04d}.png"
+
+        fig, ax = plt.subplots(figsize=(5, 5))
+        ax.imshow(mip, cmap="gray", interpolation="nearest")
+        ax.plot(cx, cy, marker="x", color="red", markersize=14, markeredgewidth=2)
+        ax.set_title(f"{pos_name} t={timepoint_index}  com=({cz:.1f}, {cy:.1f}, {cx:.1f})")
+        ax.axis("off")
+        fig.savefig(out_path, dpi=100, bbox_inches="tight")
+        plt.close(fig)
+        logger.info("DynaTrack: saved center PNG %s", out_path)

--- a/shrimpy/mantis/dynatrack.py
+++ b/shrimpy/mantis/dynatrack.py
@@ -64,13 +64,35 @@ class DynaTrackConfig:
         Track every N timepoints (1 = every timepoint).
     tracking_method : str
         Shift estimation algorithm. One of ``'pcc'`` (phase cross-correlation,
-        default), ``'multiotsu_center_of_mass'`` (multi-Otsu threshold then
-        area-weighted centroid), or ``'multiotsu_pcc'`` (multi-Otsu threshold
-        then PCC on the binary masks).
+        default), ``'intensity_center_of_mass'`` (intensity-weighted centroid
+        of the current volume relative to the ROI centre in deskew space; no
+        thresholding and no reference stack), ``'roi_center_pcc'`` (cross-
+        correlate the current volume against a synthetic Gaussian blob centred
+        on the ROI centre in deskew space; no reference stack),
+        ``'multiotsu_center_of_mass'`` (multi-Otsu threshold then area-weighted
+        centroid), or ``'multiotsu_pcc'`` (multi-Otsu threshold then PCC on the
+        binary masks). The ``'intensity_center_of_mass'`` and
+        ``'roi_center_pcc'`` methods are referenceless: they target the ROI
+        centre and correct from the first timepoint (no reference is stored).
     otsu_sigma : float
         Gaussian blur sigma for the multi-Otsu methods (default 5.0).
     otsu_component : int
         Which multi-Otsu threshold to use: 0 = lower, 1 = upper (default 0).
+    roi_blob_sigma : float
+        Gaussian sigma (in pixels) of the synthetic centred blob used as the
+        cross-correlation template for ``'roi_center_pcc'`` (default 10.0).
+        Set roughly to the radius of the structure being tracked.
+    roi_background_percentile : float | None
+        For ``'intensity_center_of_mass'``: if set (0-100), subtract this
+        intensity percentile of the volume as a background floor before
+        weighting, so a uniform background pedestal no longer pulls the
+        centroid toward the geometric centre. ``None`` (default) uses raw
+        values. Typical values: 50 (median) to 90 for a strong background.
+    roi_blur_sigma : float
+        For ``'intensity_center_of_mass'``: if > 0, Gaussian-blur the volume
+        before computing the background floor and centroid, suppressing
+        per-pixel noise / camera striping so the centroid follows the smooth
+        bright core. 0 (default) disables blurring.
     reference_update_interval : int
         Re-anchor the per-position reference every N timepoints (0 = never,
         i.e. keep the fixed t=0 reference). On a re-anchor timepoint the
@@ -110,6 +132,9 @@ class DynaTrackConfig:
     tracking_method: str = "pcc"
     otsu_sigma: float = 5.0
     otsu_component: int = 0
+    roi_blob_sigma: float = 10.0
+    roi_background_percentile: float | None = None
+    roi_blur_sigma: float = 0.0
     reference_update_interval: int = 0
     shift_estimation_channel: str = "deskewed"
     preprocessing: list[str] | None = None
@@ -119,6 +144,12 @@ class DynaTrackConfig:
     image_to_stage_matrix_xyz: list[list[float]] | None = None
     shift_log_path: str | Path | None = None
     save_debug: bool = False
+
+
+# Tracking methods whose target is the ROI centre in deskew space rather than
+# an acquired reference stack. These are "referenceless": no reference is
+# stored and correction is applied from the first timepoint.
+_ROI_CENTER_METHODS = frozenset({"intensity_center_of_mass", "roi_center_pcc"})
 
 
 # ---------------------------------------------------------------------------
@@ -450,6 +481,185 @@ def _center_of_mass(mask: torch.Tensor) -> torch.Tensor:
     return center
 
 
+def _percentile(img: torch.Tensor, percentile: float, nbins: int = 256) -> float:
+    """Approximate a percentile (0-100) of *img* via a histogram on GPU.
+
+    ``torch.quantile`` errors on very large tensors (it materialises a sorted
+    copy), so for whole deskewed volumes we estimate the percentile from a
+    256-bin histogram instead -- cheap, on-device, and accurate enough for a
+    background floor.
+    """
+    import torch
+
+    vmin = float(img.min())
+    vmax = float(img.max())
+    if vmax <= vmin:
+        return vmin
+    hist = torch.histc(img, bins=nbins, min=vmin, max=vmax)
+    cdf = torch.cumsum(hist, dim=0)
+    cdf = cdf / cdf[-1]
+    target = torch.tensor(percentile / 100.0, device=cdf.device)
+    idx = int(torch.searchsorted(cdf, target))
+    idx = min(idx, nbins - 1)
+    # Return the upper edge of the selected bin.
+    return vmin + (idx + 1) * (vmax - vmin) / nbins
+
+
+def _intensity_center_of_mass(img: torch.Tensor, background: float = 0.0) -> torch.Tensor:
+    """Compute the intensity-weighted center of mass on GPU.
+
+    Unlike :func:`_center_of_mass`, which treats every masked voxel equally
+    (area-weighted), this weights each voxel by its pixel value so brighter
+    voxels pull the centroid more strongly. No thresholding is applied.
+
+    The per-axis centroid is computed from 1-D weighted marginals (summing
+    the weights over all other axes) rather than an explicit coordinate
+    meshgrid, so memory stays at the size of the input volume.
+
+    Parameters
+    ----------
+    img : torch.Tensor
+        Input volume (Z, Y, X) on the target device; its values are the
+        weights.
+    background : float
+        Constant background subtracted from every voxel before weighting.
+        Voxels at or below it contribute zero, which sharpens the centroid
+        when there is a uniform background pedestal (default 0.0).
+
+    Returns
+    -------
+    torch.Tensor
+        Intensity-weighted center-of-mass coordinates, shape ``(ndim,)``,
+        on the same device.
+    """
+    import torch
+
+    # Subtract the background floor, then clamp: negative values (e.g. phase,
+    # or sub-background voxels) must not pull the centroid the wrong way, so
+    # weights represent non-negative "mass" only.
+    weights = (img.to(dtype=torch.float32) - background).clamp_min(0)
+    total = weights.sum()
+    if total <= 0:
+        del weights
+        return torch.zeros(img.ndim, device=img.device)
+
+    centers = []
+    for axis in range(weights.ndim):
+        other = [d for d in range(weights.ndim) if d != axis]
+        profile = weights.sum(dim=other)  # marginal weight along this axis
+        idx = torch.arange(weights.shape[axis], device=weights.device, dtype=torch.float32)
+        centers.append((profile * idx).sum() / total)
+    del weights
+    return torch.stack(centers)
+
+
+def _intensity_center_of_mass_to_roi_center(
+    current_img: torch.Tensor,
+    background_percentile: float | None = None,
+    blur_sigma: float = 0.0,
+) -> tuple[float, ...]:
+    """Compute shift from the ROI centre to the intensity-weighted centroid.
+
+    The target ("reference") coordinate is the geometric centre of the volume
+    -- i.e. the centre of the ROI in deskew space -- rather than a reference
+    stack's centroid. The shift is the intensity-weighted center of mass of
+    *current_img* minus that ROI centre (ZYX pixel order), so a positive shift
+    means the bright structure sits past the centre on that axis. No reference
+    stack and no thresholding are used. All computation stays on device.
+
+    Parameters
+    ----------
+    current_img : torch.Tensor
+        Current volume (Z, Y, X) on the target device.
+    background_percentile : float | None
+        If given (0-100), subtract that intensity percentile of the volume as
+        a background floor before weighting, so a uniform background pedestal
+        no longer pulls the centroid toward the geometric centre. ``None``
+        (default) uses the raw values.
+    blur_sigma : float
+        If > 0, Gaussian-blur the volume before weighting (and before the
+        background percentile). Suppresses per-pixel noise / camera striping
+        so the centroid follows the smooth bright core rather than jittering
+        on speckle. 0 (default) disables blurring.
+    """
+    import torch
+
+    img = current_img.to(dtype=torch.float32)
+    if blur_sigma and blur_sigma > 0:
+        img = _gaussian_blur_3d(img, blur_sigma)
+
+    background = (
+        _percentile(img, background_percentile) if background_percentile is not None else 0.0
+    )
+    center_of_mass = _intensity_center_of_mass(img, background=background)
+    roi_center = torch.tensor(
+        [(s - 1) / 2.0 for s in img.shape],
+        device=img.device,
+        dtype=torch.float32,
+    )
+    shift_zyx = center_of_mass - roi_center
+    logger.debug(
+        "intensity_center_of_mass: com=%s roi_center=%s background=%.4g "
+        "blur_sigma=%.2g shift=%s",
+        center_of_mass.tolist(),
+        roi_center.tolist(),
+        background,
+        blur_sigma,
+        shift_zyx.tolist(),
+    )
+    del center_of_mass, roi_center, img
+    return tuple(float(s) for s in shift_zyx)
+
+
+def _centered_gaussian_blob(
+    shape: tuple[int, ...],
+    sigma: float,
+    device: torch.device,
+) -> torch.Tensor:
+    """Build a Gaussian blob of *shape* centred on the geometric centre.
+
+    Used as a synthetic cross-correlation template for ``roi_center_pcc``:
+    the centre of the blob is the ROI centre in deskew space. Built as a
+    separable outer product of 1-D Gaussians so memory stays at the volume
+    size.
+    """
+    import torch
+
+    axes_1d = []
+    for n in shape:
+        idx = torch.arange(n, device=device, dtype=torch.float32)
+        center = (n - 1) / 2.0
+        axes_1d.append(torch.exp(-0.5 * ((idx - center) / sigma) ** 2))
+    blob = axes_1d[0]
+    for g in axes_1d[1:]:
+        blob = blob.unsqueeze(-1) * g  # outer product, growing rank
+    return blob
+
+
+def _roi_center_pcc(
+    current_img: torch.Tensor,
+    blob_sigma: float = 10.0,
+    maximum_shift: float = 1.0,
+) -> tuple[int, ...]:
+    """Compute shift by cross-correlating against a centred Gaussian blob.
+
+    The reference is a synthetic Gaussian blob centred on the ROI centre in
+    deskew space (no acquired reference stack). Cross-correlating the current
+    volume against it locates the bright structure relative to the centre, so
+    the returned shift (ZYX pixel order) is the structure's offset from the
+    ROI centre. All computation stays on the input tensor's device.
+    """
+    import torch
+
+    blob = _centered_gaussian_blob(tuple(current_img.shape), blob_sigma, current_img.device)
+    # _phase_cross_corr(ref, mov) returns the shift of *mov* relative to *ref*.
+    # With the centred blob as the reference, that shift is the structure's
+    # displacement from the ROI centre.
+    result = _phase_cross_corr(blob, current_img.to(dtype=torch.float32), maximum_shift)
+    del blob
+    return result
+
+
 def _multiotsu_center_of_mass(
     ref_img: torch.Tensor,
     mov_img: torch.Tensor,
@@ -739,14 +949,15 @@ class DynaTrackUpdater(PositionUpdater):
                 )
                 selected = next(iter(channels_zyx.values()))
             self._save_debug_channels(channels_zyx, timepoint_index, position_index)
-            # For center-of-mass tracking, save a PNG of the thresholded mask
-            # (Z max-projection) with the computed centroid marked, for a quick
-            # visual check of where the tracker is centring.
-            if (
-                self._debug_zarr_path is not None
-                and self._config.tracking_method == "multiotsu_center_of_mass"
-            ):
-                self._save_center_png(selected, timepoint_index, position_index)
+            # For center-of-mass tracking, save a PNG (Z max-projection) with
+            # the computed centroid marked, for a quick visual check of where
+            # the tracker is centring. multiotsu -> thresholded mask;
+            # intensity -> the background-filtered weights the centroid uses.
+            if self._debug_zarr_path is not None:
+                if self._config.tracking_method == "multiotsu_center_of_mass":
+                    self._save_center_png(selected, timepoint_index, position_index)
+                elif self._config.tracking_method == "intensity_center_of_mass":
+                    self._save_intensity_center_png(selected, timepoint_index, position_index)
             # Clone into a compact standalone tensor. A bare ``.detach()`` is a
             # view that keeps the *entire* preprocessor output alive (all
             # channels share one parent tensor), so a stored reference would
@@ -766,28 +977,33 @@ class DynaTrackUpdater(PositionUpdater):
             # No preprocessing: move the raw stack to the device directly.
             current_stack_zyx = torch.as_tensor(raw_stack, device=device, dtype=torch.float32)
 
-        # (Re)anchor the reference: store it on first encounter, and re-anchor
-        # every ``reference_update_interval`` timepoints. On a re-anchor
-        # timepoint we adopt the current image as the new reference and apply
-        # NO correction (return position unchanged) -- the current stage
-        # position becomes the new baseline; correcting here would jump the
-        # stage against a reference we are about to discard.
-        interval = self._config.reference_update_interval
-        if (position_index not in self._reference_stacks_zyx) or (
-            interval and timepoint_index % interval == 0
-        ):
-            self._reference_stacks_zyx[position_index] = current_stack_zyx
-            ref_total = sum(a.nbytes for a in self._reference_stacks_zyx.values())
-            logger.info(
-                f"DynaTrack: stored reference stack for p={position_index} from t={timepoint_index} "
-                f"(zyx_shape={current_stack_zyx.shape})"
-            )
-            logger.debug(
-                f"DynaTrack[mem]: after store_ref p={position_index} t={timepoint_index} "
-                f"rss={_rss_gb():.2f} GB refs={len(self._reference_stacks_zyx)} "
-                f"refs_total={ref_total / 1024**3:.2f} GB"
-            )
-            return position
+        # Referenceless methods target the ROI centre in deskew space, so they
+        # need no stored reference and correct from the very first timepoint.
+        referenceless = self._config.tracking_method in _ROI_CENTER_METHODS
+
+        if not referenceless:
+            # (Re)anchor the reference: store it on first encounter, and re-anchor
+            # every ``reference_update_interval`` timepoints. On a re-anchor
+            # timepoint we adopt the current image as the new reference and apply
+            # NO correction (return position unchanged) -- the current stage
+            # position becomes the new baseline; correcting here would jump the
+            # stage against a reference we are about to discard.
+            interval = self._config.reference_update_interval
+            if (position_index not in self._reference_stacks_zyx) or (
+                interval and timepoint_index % interval == 0
+            ):
+                self._reference_stacks_zyx[position_index] = current_stack_zyx
+                ref_total = sum(a.nbytes for a in self._reference_stacks_zyx.values())
+                logger.info(
+                    f"DynaTrack: stored reference stack for p={position_index} from t={timepoint_index} "
+                    f"(zyx_shape={current_stack_zyx.shape})"
+                )
+                logger.debug(
+                    f"DynaTrack[mem]: after store_ref p={position_index} t={timepoint_index} "
+                    f"rss={_rss_gb():.2f} GB refs={len(self._reference_stacks_zyx)} "
+                    f"refs_total={ref_total / 1024**3:.2f} GB"
+                )
+                return position
 
         # Skip tracking if not on a tracking interval
         if (
@@ -800,7 +1016,11 @@ class DynaTrackUpdater(PositionUpdater):
             )
             return position
 
-        reference_stack_zyx = self._reference_stacks_zyx[position_index]
+        # Referenceless methods ignore the reference argument; pass the current
+        # stack as a placeholder so the signature is satisfied.
+        reference_stack_zyx = (
+            current_stack_zyx if referenceless else self._reference_stacks_zyx[position_index]
+        )
         logger.debug(
             f"DynaTrack[mem]: before compute_shift p={position_index} t={timepoint_index} "
             f"rss={_rss_gb():.2f} GB"
@@ -896,6 +1116,18 @@ class DynaTrackUpdater(PositionUpdater):
         method = cfg.tracking_method
         if method == "pcc":
             shifts_zyx_px = _phase_cross_corr(reference_zyx, current_zyx, cfg.maximum_shift)
+        elif method == "intensity_center_of_mass":
+            shifts_zyx_px = _intensity_center_of_mass_to_roi_center(
+                current_zyx,
+                background_percentile=cfg.roi_background_percentile,
+                blur_sigma=cfg.roi_blur_sigma,
+            )
+        elif method == "roi_center_pcc":
+            shifts_zyx_px = _roi_center_pcc(
+                current_zyx,
+                blob_sigma=cfg.roi_blob_sigma,
+                maximum_shift=cfg.maximum_shift,
+            )
         elif method == "multiotsu_center_of_mass":
             shifts_zyx_px = _multiotsu_center_of_mass(
                 reference_zyx,
@@ -914,7 +1146,8 @@ class DynaTrackUpdater(PositionUpdater):
         else:
             raise ValueError(
                 f"Unknown tracking_method={method!r}. "
-                "Use 'pcc', 'multiotsu_center_of_mass', or 'multiotsu_pcc'."
+                "Use 'pcc', 'intensity_center_of_mass', 'roi_center_pcc', "
+                "'multiotsu_center_of_mass', or 'multiotsu_pcc'."
             )
 
         # 2. Convert pixels to microns
@@ -1051,3 +1284,61 @@ class DynaTrackUpdater(PositionUpdater):
         fig.savefig(out_path, dpi=100, bbox_inches="tight")
         plt.close(fig)
         logger.info("DynaTrack: saved center PNG %s", out_path)
+
+    def _save_intensity_center_png(
+        self,
+        volume: torch.Tensor,
+        timepoint_index: int,
+        position_index: int,
+    ) -> None:
+        """Save a PNG of the background-filtered volume (Z max-projection) for
+        ``intensity_center_of_mass`` tracking, with the intensity-weighted
+        centroid (red x) and the ROI centre (cyan +) marked. This is exactly
+        the weighted image the centroid is computed from, so it shows whether
+        the tracker is locking onto the structure or being pulled to centre by
+        residual background. Written to ``dynatrack_centers/`` next to the
+        debug zarr, one PNG per position per timepoint.
+        """
+        if self._debug_zarr_path is None:
+            return
+
+        import matplotlib
+        import torch
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+        # Reproduce the filtering the centroid uses: optional blur, then
+        # subtract the background floor (if configured) and clamp negatives.
+        img = volume.to(dtype=torch.float32)
+        blur_sigma = self._config.roi_blur_sigma
+        if blur_sigma and blur_sigma > 0:
+            img = _gaussian_blur_3d(img, blur_sigma)
+        pct = self._config.roi_background_percentile
+        background = _percentile(img, pct) if pct is not None else 0.0
+        filtered = (img - background).clamp_min(0)
+
+        cz, cy, cx = (
+            float(c) for c in _intensity_center_of_mass(img, background=background).tolist()
+        )
+        rz, ry, rx = ((s - 1) / 2.0 for s in volume.shape)
+        mip = filtered.amax(dim=0).detach().cpu().numpy()  # (Y, X) projection over Z
+
+        raw_name = self._debug_position_names.get(position_index, f"p{position_index}")
+        pos_name = "".join(ch for ch in raw_name if ch.isalnum()) or f"p{position_index}"
+        out_dir = self._debug_zarr_path.with_name("dynatrack_centers")
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_path = out_dir / f"{pos_name}_t{timepoint_index:04d}.png"
+
+        fig, ax = plt.subplots(figsize=(5, 5))
+        ax.imshow(mip, cmap="magma", interpolation="nearest")
+        ax.plot(rx, ry, marker="+", color="cyan", markersize=16, markeredgewidth=2)
+        ax.plot(cx, cy, marker="x", color="red", markersize=14, markeredgewidth=2)
+        ax.set_title(
+            f"{pos_name} t={timepoint_index}  com=({cz:.1f}, {cy:.1f}, {cx:.1f})  "
+            f"bg={background:.4g}"
+        )
+        ax.axis("off")
+        fig.savefig(out_path, dpi=100, bbox_inches="tight")
+        plt.close(fig)
+        logger.info("DynaTrack: saved intensity-center PNG %s", out_path)

--- a/shrimpy/tests/test_dynatrack.py
+++ b/shrimpy/tests/test_dynatrack.py
@@ -9,9 +9,14 @@ import torch
 from shrimpy.mantis.dynatrack import (
     DynaTrackConfig,
     DynaTrackUpdater,
+    _binary_mask,
     _center_crop,
+    _center_of_mass,
+    _gaussian_blur_3d,
     _limit_shifts_zyx,
     _match_shape,
+    _multiotsu_center_of_mass,
+    _multiotsu_pcc,
     _pad_to_shape,
     _phase_cross_corr,
 )
@@ -513,3 +518,176 @@ class TestShiftLogging:
         updater.update(0, 0, pos, frames)
         updater.update(1, 0, pos, mov)
         # No exception, no file created — just verifying no crash
+
+
+# ---------------------------------------------------------------------------
+# Multi-Otsu tracking method tests (ported from 230_dynatrack_center_of_mass)
+# ---------------------------------------------------------------------------
+
+
+class TestGaussianBlur3D:
+    def test_output_shape_unchanged(self):
+        """Blur should preserve the input shape."""
+        vol = torch.rand(8, 32, 32)
+        result = _gaussian_blur_3d(vol, sigma=2.0)
+        assert result.shape == vol.shape
+
+    def test_smooths_values(self):
+        """Blurred volume should have a smaller range than the original."""
+        vol = torch.rand(8, 32, 32)
+        result = _gaussian_blur_3d(vol, sigma=3.0)
+        assert (result.max() - result.min()) <= (vol.max() - vol.min())
+
+    def test_zero_sigma_noop(self):
+        """Sigma=0 should return the input unchanged."""
+        vol = torch.rand(8, 32, 32)
+        result = _gaussian_blur_3d(vol, sigma=0.0)
+        assert torch.equal(result, vol)
+
+
+class TestBinaryMask:
+    def test_returns_bool_tensor(self):
+        """Binary mask should return a boolean tensor on the same device."""
+        rng = np.random.default_rng(42)
+        vol = rng.random((8, 32, 32)).astype(np.float64) * 0.2
+        vol[3:6, 12:20, 12:20] = 0.9
+        vol_t = torch.as_tensor(vol, dtype=torch.float32)
+        mask = _binary_mask(vol_t, sigma=1.0, otsu_component=0)
+        assert mask.dtype == torch.bool
+        assert mask.sum() > 0  # at least some True voxels
+
+    def test_otsu_component_selects_threshold(self):
+        """Higher otsu_component should produce a stricter (smaller) mask."""
+        rng = np.random.default_rng(42)
+        vol = rng.random((8, 32, 32)).astype(np.float64) * 0.3
+        vol[2:6, 8:24, 8:24] = 0.6
+        vol[3:5, 12:20, 12:20] = 0.95
+        vol_t = torch.as_tensor(vol, dtype=torch.float32)
+        mask_0 = _binary_mask(vol_t, sigma=1.0, otsu_component=0)
+        mask_1 = _binary_mask(vol_t, sigma=1.0, otsu_component=1)
+        assert mask_0.sum() >= mask_1.sum()
+
+
+class TestCenterOfMass:
+    def test_single_blob(self):
+        """Center of mass of a centred blob should be near the middle."""
+        mask = torch.zeros(10, 10, 10, dtype=torch.bool)
+        mask[3:7, 3:7, 3:7] = True
+        center = _center_of_mass(mask)
+        expected = torch.tensor([4.5, 4.5, 4.5])
+        assert torch.allclose(center, expected, atol=0.5)
+
+    def test_empty_returns_zeros(self):
+        """Empty mask should return zero center."""
+        mask = torch.zeros(10, 10, 10, dtype=torch.bool)
+        center = _center_of_mass(mask)
+        assert torch.equal(center, torch.zeros(3))
+
+
+class TestMultiotsuCenterOfMass:
+    def test_detects_shift(self):
+        """Center of mass should detect a spatial shift between two volumes."""
+        rng = np.random.default_rng(42)
+        ref = rng.random((8, 64, 64)).astype(np.float64) * 0.1
+        ref[2:6, 20:40, 20:40] = 0.9  # bright blob
+
+        # Shift the blob by +5 in Y
+        mov = rng.random((8, 64, 64)).astype(np.float64) * 0.1
+        mov[2:6, 25:45, 20:40] = 0.9
+
+        ref_t = torch.as_tensor(ref, dtype=torch.float32)
+        mov_t = torch.as_tensor(mov, dtype=torch.float32)
+        shift = _multiotsu_center_of_mass(ref_t, mov_t, sigma=1.0, otsu_component=0)
+
+        # Y shift should be approximately +5
+        assert abs(shift[1] - 5.0) < 2.0
+        # X and Z should be near zero
+        assert abs(shift[2]) < 2.0
+        assert abs(shift[0]) < 2.0
+
+
+class TestMultiotsuPcc:
+    def test_detects_shift(self):
+        """Multiotsu PCC should detect a known shift via binary mask PCC."""
+        rng = np.random.default_rng(42)
+        ref = rng.random((8, 64, 64)).astype(np.float64) * 0.1
+        ref[2:6, 15:50, 15:50] = 0.9
+
+        mov = rng.random((8, 64, 64)).astype(np.float64) * 0.1
+        mov[2:6, 18:53, 15:50] = 0.9  # shifted +3 in Y
+
+        ref_t = torch.as_tensor(ref, dtype=torch.float32)
+        mov_t = torch.as_tensor(mov, dtype=torch.float32)
+        shift = _multiotsu_pcc(ref_t, mov_t, sigma=1.0, otsu_component=0)
+
+        assert abs(shift[1] - 3) <= 1  # Y shift ~3
+        assert abs(shift[2]) <= 1  # X near zero
+
+
+class TestDynaTrackUpdaterMultiotsu:
+    def _make_blob_frames(self, rng, y_start, n_z=8, ny=64, nx=64):
+        """Create frames with a bright blob at a given Y position."""
+        frames = []
+        for z in range(n_z):
+            frame = rng.random((ny, nx)).astype(np.float64) * 0.1
+            if 2 <= z < 6:
+                frame[y_start : y_start + 20, 20:40] = 0.9
+            frames.append(frame)
+        return frames
+
+    def test_multiotsu_center_of_mass_detects_shift(self):
+        """update() with multiotsu_center_of_mass detects a blob shift."""
+        rng = np.random.default_rng(42)
+        config = DynaTrackConfig(
+            scale_yx=1.0,
+            scale_z=1.0,
+            tracking_method="multiotsu_center_of_mass",
+            otsu_sigma=1.0,
+            preprocessing=[],
+        )
+        updater = DynaTrackUpdater(config=config)
+        pos = PositionCoordinates(x=100.0, y=200.0, z=50.0)
+
+        ref_frames = self._make_blob_frames(rng, y_start=15)
+        mov_frames = self._make_blob_frames(rng, y_start=20)  # shifted +5 in Y
+
+        updater.update(0, 0, pos, ref_frames)
+        result = updater.update(1, 0, pos, mov_frames)
+
+        # Y position should have changed
+        assert result.y != 200.0
+
+    def test_multiotsu_pcc_detects_shift(self):
+        """update() with multiotsu_pcc detects a blob shift."""
+        rng = np.random.default_rng(42)
+        config = DynaTrackConfig(
+            scale_yx=1.0,
+            scale_z=1.0,
+            tracking_method="multiotsu_pcc",
+            otsu_sigma=1.0,
+            preprocessing=[],
+        )
+        updater = DynaTrackUpdater(config=config)
+        pos = PositionCoordinates(x=100.0, y=200.0, z=50.0)
+
+        ref_frames = self._make_blob_frames(rng, y_start=15)
+        mov_frames = self._make_blob_frames(rng, y_start=20)
+
+        updater.update(0, 0, pos, ref_frames)
+        result = updater.update(1, 0, pos, mov_frames)
+
+        assert result.y != 200.0
+
+    def test_invalid_method_raises(self):
+        """Unknown tracking_method should raise ValueError."""
+        rng = np.random.default_rng(42)
+        config = DynaTrackConfig(
+            scale_yx=1.0, scale_z=1.0, tracking_method="unknown_method", preprocessing=[]
+        )
+        updater = DynaTrackUpdater(config=config)
+        pos = PositionCoordinates(x=100.0, y=200.0, z=50.0)
+
+        frames = [rng.random((64, 64)) for _ in range(8)]
+        updater.update(0, 0, pos, frames)  # store ref
+        with pytest.raises(ValueError, match="Unknown tracking_method"):
+            updater.update(1, 0, pos, frames)

--- a/shrimpy/tests/test_dynatrack.py
+++ b/shrimpy/tests/test_dynatrack.py
@@ -606,11 +606,13 @@ class TestIntensityCenterOfMass:
         center = _intensity_center_of_mass(img)
         assert center[2] > 4.5  # X pulled toward the bright slice
 
-    def test_zero_weight_returns_zeros(self):
-        """All-zero weights return a zero centre rather than dividing by zero."""
+    def test_zero_weight_returns_geometric_center(self):
+        """All-zero weights have an undefined centroid; fall back to the
+        geometric centre (not the origin) so a ROI-centre shift is zero rather
+        than a spurious half-volume jump toward the corner."""
         img = torch.zeros(10, 10, 10)
         center = _intensity_center_of_mass(img)
-        assert torch.equal(center, torch.zeros(3))
+        assert torch.allclose(center, torch.tensor([4.5, 4.5, 4.5]))
 
     def test_negative_values_clamped(self):
         """Negative values are clamped so they don't pull the centroid."""
@@ -664,6 +666,24 @@ class TestIntensityCenterOfMassToRoiCenter:
         img[2:6, 40:50, 28:36] = 1.0  # shifted toward higher Y
         shift = _intensity_center_of_mass_to_roi_center(img)
         assert shift[1] > 0  # Y offset from centre is positive
+
+    def test_blank_volume_zero_shift(self):
+        """A blank volume (no signal) yields zero shift, not a half-volume jump.
+
+        With the degenerate centroid reported as the origin, the shift would be
+        ``-roi_center`` (~half the volume on every axis), commanding a large
+        spurious stage move. It must be ~zero instead.
+        """
+        img = torch.zeros(8, 64, 64)
+        shift = _intensity_center_of_mass_to_roi_center(img)
+        assert all(abs(s) < 1e-3 for s in shift)
+
+    def test_over_subtracted_volume_zero_shift(self):
+        """A uniform pedestal fully removed by background subtraction also has
+        no positive mass, so it must yield zero shift rather than a jump."""
+        img = torch.full((8, 64, 64), 3.0)
+        shift = _intensity_center_of_mass_to_roi_center(img, background_percentile=99.0)
+        assert all(abs(s) < 1e-3 for s in shift)
         assert abs(shift[2]) < 2.0  # X stays near centre
 
 
@@ -858,3 +878,86 @@ class TestRoiCenterMethodsFlow:
 
         assert result.y != 200.0
         assert 0 not in updater._reference_stacks_zyx
+
+
+# ---------------------------------------------------------------------------
+# wants_reference_refresh: gates the manager's missing-baseline behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestWantsReferenceRefresh:
+    def test_reference_based_refreshes_on_interval(self):
+        """Reference-based methods re-anchor every Nth timepoint."""
+        updater = DynaTrackUpdater(
+            config=DynaTrackConfig(
+                scale_yx=1.0, scale_z=1.0, tracking_method="pcc", reference_update_interval=4
+            )
+        )
+        assert [updater.wants_reference_refresh(t) for t in (0, 1, 4, 8)] == [
+            True,
+            False,
+            True,
+            True,
+        ]
+
+    def test_no_interval_never_refreshes(self):
+        updater = DynaTrackUpdater(
+            config=DynaTrackConfig(
+                scale_yx=1.0, scale_z=1.0, tracking_method="pcc", reference_update_interval=0
+            )
+        )
+        assert not any(updater.wants_reference_refresh(t) for t in range(5))
+
+    def test_referenceless_never_refreshes(self):
+        """Referenceless methods correct every timepoint and keep no reference,
+        so they must never report a refresh -- even with an interval set --
+        otherwise a missing baseline would let a real correction run against an
+        unanchored (race-prone) store value."""
+        for method in ("intensity_center_of_mass", "roi_center_pcc"):
+            updater = DynaTrackUpdater(
+                config=DynaTrackConfig(
+                    scale_yx=1.0,
+                    scale_z=1.0,
+                    tracking_method=method,
+                    reference_update_interval=4,
+                )
+            )
+            assert not any(updater.wants_reference_refresh(t) for t in range(9))
+
+
+class TestReferenceUpdateIntervalWarning:
+    def test_warns_for_referenceless_with_interval(self, caplog):
+        with caplog.at_level("WARNING", logger="shrimpy.mantis.dynatrack"):
+            DynaTrackUpdater(
+                config=DynaTrackConfig(
+                    scale_yx=1.0,
+                    scale_z=1.0,
+                    tracking_method="intensity_center_of_mass",
+                    reference_update_interval=4,
+                )
+            )
+        assert any("ignored for referenceless" in r.message for r in caplog.records)
+
+    def test_no_warning_for_reference_based(self, caplog):
+        with caplog.at_level("WARNING", logger="shrimpy.mantis.dynatrack"):
+            DynaTrackUpdater(
+                config=DynaTrackConfig(
+                    scale_yx=1.0,
+                    scale_z=1.0,
+                    tracking_method="pcc",
+                    reference_update_interval=4,
+                )
+            )
+        assert not any("ignored for referenceless" in r.message for r in caplog.records)
+
+    def test_no_warning_for_referenceless_without_interval(self, caplog):
+        with caplog.at_level("WARNING", logger="shrimpy.mantis.dynatrack"):
+            DynaTrackUpdater(
+                config=DynaTrackConfig(
+                    scale_yx=1.0,
+                    scale_z=1.0,
+                    tracking_method="intensity_center_of_mass",
+                    reference_update_interval=0,
+                )
+            )
+        assert not any("ignored for referenceless" in r.message for r in caplog.records)

--- a/shrimpy/tests/test_dynatrack.py
+++ b/shrimpy/tests/test_dynatrack.py
@@ -12,13 +12,18 @@ from shrimpy.mantis.dynatrack import (
     _binary_mask,
     _center_crop,
     _center_of_mass,
+    _centered_gaussian_blob,
     _gaussian_blur_3d,
+    _intensity_center_of_mass,
+    _intensity_center_of_mass_to_roi_center,
     _limit_shifts_zyx,
     _match_shape,
     _multiotsu_center_of_mass,
     _multiotsu_pcc,
     _pad_to_shape,
+    _percentile,
     _phase_cross_corr,
+    _roi_center_pcc,
 )
 from shrimpy.mantis.position_update import PositionCoordinates
 
@@ -584,6 +589,112 @@ class TestCenterOfMass:
         assert torch.equal(center, torch.zeros(3))
 
 
+class TestIntensityCenterOfMass:
+    def test_uniform_blob_matches_geometric_center(self):
+        """A uniform-intensity region centres at its geometric middle."""
+        img = torch.zeros(10, 10, 10)
+        img[3:7, 3:7, 3:7] = 1.0
+        center = _intensity_center_of_mass(img)
+        expected = torch.tensor([4.5, 4.5, 4.5])
+        assert torch.allclose(center, expected, atol=0.1)
+
+    def test_brighter_voxels_pull_center(self):
+        """Intensity weighting pulls the centroid toward the brightest voxels."""
+        img = torch.zeros(10, 10, 10)
+        img[3:7, 3:7, 3:7] = 1.0
+        img[3:7, 3:7, 6] = 100.0  # one X slice much brighter
+        center = _intensity_center_of_mass(img)
+        assert center[2] > 4.5  # X pulled toward the bright slice
+
+    def test_zero_weight_returns_zeros(self):
+        """All-zero weights return a zero centre rather than dividing by zero."""
+        img = torch.zeros(10, 10, 10)
+        center = _intensity_center_of_mass(img)
+        assert torch.equal(center, torch.zeros(3))
+
+    def test_negative_values_clamped(self):
+        """Negative values are clamped so they don't pull the centroid."""
+        img = torch.zeros(10, 10, 10)
+        img[3:7, 3:7, 3:7] = 1.0
+        img[0, 0, 0] = -1000.0  # would dominate if not clamped
+        center = _intensity_center_of_mass(img)
+        expected = torch.tensor([4.5, 4.5, 4.5])
+        assert torch.allclose(center, expected, atol=0.1)
+
+    def test_background_subtraction_sharpens_centroid(self):
+        """Subtracting a background floor removes a uniform pedestal's pull."""
+        # Bright blob off-centre on top of a uniform background pedestal.
+        img = torch.full((8, 64, 64), 0.2)
+        img[2:6, 44:52, 28:36] += 5.0  # off-centre structure
+        # Without background subtraction the pedestal pulls the centroid back
+        # toward the geometric centre (31.5 in Y).
+        c_raw = _intensity_center_of_mass(img)
+        # Subtracting the pedestal lets the structure dominate -> centroid moves
+        # further toward the structure (higher Y).
+        c_sub = _intensity_center_of_mass(img, background=0.2)
+        assert c_sub[1] > c_raw[1]
+
+
+class TestPercentile:
+    def test_matches_known_distribution(self):
+        """Histogram percentile is close to the true value for a ramp."""
+        img = torch.arange(1000, dtype=torch.float32).reshape(10, 10, 10)
+        p50 = _percentile(img, 50.0)
+        # Median of 0..999 is ~499.5; histogram estimate within one bin width.
+        assert abs(p50 - 499.5) < 1000 / 256 + 1
+
+    def test_constant_image_returns_value(self):
+        """A flat image returns its single value for any percentile."""
+        img = torch.full((4, 8, 8), 3.0)
+        assert _percentile(img, 90.0) == pytest.approx(3.0)
+
+
+class TestIntensityCenterOfMassToRoiCenter:
+    def test_centered_structure_zero_shift(self):
+        """A structure at the ROI centre yields ~zero shift."""
+        img = torch.zeros(8, 64, 64)
+        img[2:6, 30:34, 30:34] = 1.0  # centred near (3.5, 31.5, 31.5)
+        shift = _intensity_center_of_mass_to_roi_center(img)
+        # ROI centre is ((8-1)/2, (64-1)/2, (64-1)/2) = (3.5, 31.5, 31.5)
+        assert all(abs(s) < 1.0 for s in shift)
+
+    def test_offset_structure_positive_shift(self):
+        """A structure past the centre in +Y yields a positive Y shift."""
+        img = torch.zeros(8, 64, 64)
+        img[2:6, 40:50, 28:36] = 1.0  # shifted toward higher Y
+        shift = _intensity_center_of_mass_to_roi_center(img)
+        assert shift[1] > 0  # Y offset from centre is positive
+        assert abs(shift[2]) < 2.0  # X stays near centre
+
+
+class TestCenteredGaussianBlob:
+    def test_peak_at_center(self):
+        """The blob's maximum sits at the geometric centre of the volume."""
+        blob = _centered_gaussian_blob((8, 32, 32), sigma=4.0, device=torch.device("cpu"))
+        peak = np.unravel_index(int(torch.argmax(blob)), tuple(blob.shape))
+        # Centre for odd/even sizes rounds to floor((n-1)/2) at the peak voxel
+        assert peak[0] in (3, 4)
+        assert peak[1] in (15, 16)
+        assert peak[2] in (15, 16)
+
+
+class TestRoiCenterPcc:
+    def test_centered_structure_zero_shift(self):
+        """A blob-like structure at the centre correlates with ~zero shift."""
+        img = torch.zeros(8, 64, 64)
+        img[2:6, 28:36, 28:36] = 1.0  # near the ROI centre
+        shift = _roi_center_pcc(img, blob_sigma=4.0)
+        assert abs(shift[1]) <= 2
+        assert abs(shift[2]) <= 2
+
+    def test_offset_structure_detected(self):
+        """An off-centre bright blob yields a non-zero detected offset in Y."""
+        img = torch.zeros(8, 64, 64)
+        img[2:6, 44:52, 28:36] = 1.0  # shifted +~16 in Y from centre
+        shift = _roi_center_pcc(img, blob_sigma=4.0)
+        assert shift[1] > 4  # detected positive Y offset from centre
+
+
 class TestMultiotsuCenterOfMass:
     def test_detects_shift(self):
         """Center of mass should detect a spatial shift between two volumes."""
@@ -691,3 +802,59 @@ class TestDynaTrackUpdaterMultiotsu:
         updater.update(0, 0, pos, frames)  # store ref
         with pytest.raises(ValueError, match="Unknown tracking_method"):
             updater.update(1, 0, pos, frames)
+
+
+# ---------------------------------------------------------------------------
+# Referenceless ROI-centre tracking flow (intensity_center_of_mass, roi_center_pcc)
+# ---------------------------------------------------------------------------
+
+
+class TestRoiCenterMethodsFlow:
+    def _make_offset_blob_frames(self, rng, y_start, n_z=8, ny=64, nx=64):
+        """Frames with a bright blob whose Y position is offset from centre."""
+        frames = []
+        for z in range(n_z):
+            frame = rng.random((ny, nx)).astype(np.float64) * 0.1
+            if 2 <= z < 6:
+                frame[y_start : y_start + 8, 28:36] = 0.9
+            frames.append(frame)
+        return frames
+
+    def test_intensity_center_of_mass_corrects_from_t0(self):
+        """Referenceless: the first timepoint already applies a correction
+        (no reference stored, no unchanged-return)."""
+        rng = np.random.default_rng(42)
+        config = DynaTrackConfig(
+            scale_yx=1.0,
+            scale_z=1.0,
+            tracking_method="intensity_center_of_mass",
+            preprocessing=[],
+        )
+        updater = DynaTrackUpdater(config=config)
+        pos = PositionCoordinates(x=100.0, y=200.0, z=50.0)
+
+        # Blob offset toward higher Y -> positive Y image shift -> stage moves -Y.
+        frames = self._make_offset_blob_frames(rng, y_start=44)
+        result = updater.update(0, 0, pos, frames)
+
+        assert result.y != 200.0  # corrected on the very first timepoint
+        assert 0 not in updater._reference_stacks_zyx  # no reference stored
+
+    def test_roi_center_pcc_corrects_from_t0(self):
+        """Referenceless PCC-vs-ROI-centre also corrects from t=0."""
+        rng = np.random.default_rng(42)
+        config = DynaTrackConfig(
+            scale_yx=1.0,
+            scale_z=1.0,
+            tracking_method="roi_center_pcc",
+            roi_blob_sigma=4.0,
+            preprocessing=[],
+        )
+        updater = DynaTrackUpdater(config=config)
+        pos = PositionCoordinates(x=100.0, y=200.0, z=50.0)
+
+        frames = self._make_offset_blob_frames(rng, y_start=44)
+        result = updater.update(0, 0, pos, frames)
+
+        assert result.y != 200.0
+        assert 0 not in updater._reference_stacks_zyx


### PR DESCRIPTION
Closes #272. Sub-PR of #267. Stacks on #287 (PR-5). Final sub-PR of the split.

Sub-PR 6/6. Replaces #278.

## Summary

Add two new tracking methods to DynaTrack:

- **Multi-Otsu center-of-mass tracking** — segments the deskewed volume with multi-Otsu thresholding and tracks the intensity-weighted center of mass. Useful for samples with a well-defined bright structure (e.g. fluorescent neuromast).
- **Blob PCC tracking** — phase cross-correlation on the segmented blob mask rather than the raw image, giving a more robust signal in the presence of background drift.
- **Referenceless ROI-center tracking** — intensity COM and blob PCC variants that don't need a reference stack at all (no `_reference_stacks_zyx` lookup); the ROI re-centers on the current intensity each timepoint.

Adds `matplotlib` dependency for debug plots; documents the new options in `dynatrack_demo.yaml`.

## Test plan

- [x] +26 new unit tests for COM/PCC/blob tracking methods.
- [x] No test regressions vs PR-5 baseline; 0 failures.

## Commits

Cherry-picked from #278 (preserving original authorship):
- DynaTrack: multi-Otsu center-of-mass & PCC tracking methods
- DynaTrack: document multi-Otsu options in demo config; add matplotlib dep
- DynaTrack: referenceless ROI-center tracking (intensity COM & blob PCC)