### PR TITLE
Switch pymmcore-plus to main; drop summary_metadata.json workaround

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,11 @@ local_scheme = "no-local-version"
 packages = ["shrimpy"]
 
 [tool.uv.sources]
-pymmcore-plus = { git = "https://github.com/ieivanov/pymmcore-plus", branch = "dev" }
+pymmcore-plus = { git = "https://github.com/ieivanov/pymmcore-plus", branch = "main" }
+# Fork currently carries no patches of its own -- it is in sync with upstream main,
+# which is ahead of the v0.3.2 release by the "fov names for plate positions with
+# grid_plan" commit that our plate + grid_plan configs need. Switch to a plain
+# "ome-writers[acquire-zarr]>=0.3.3" pin once that ships.
 ome-writers = { git = "https://github.com/ieivanov/ome-writers", branch = "main" }
 useq-schema = { git = "https://github.com/ieivanov/useq-schema", branch = "main" }
 napari-deskew-preview = { git = "ssh://git@github.com/czbiohub-sf/napari-deskew-preview", branch = "main" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,10 +73,6 @@ packages = ["shrimpy"]
 
 [tool.uv.sources]
 pymmcore-plus = { git = "https://github.com/ieivanov/pymmcore-plus", branch = "main" }
-# Fork currently carries no patches of its own -- it is in sync with upstream main,
-# which is ahead of the v0.3.2 release by the "fov names for plate positions with
-# grid_plan" commit that our plate + grid_plan configs need. Switch to a plain
-# "ome-writers[acquire-zarr]>=0.3.3" pin once that ships.
 ome-writers = { git = "https://github.com/ieivanov/ome-writers", branch = "main" }
 useq-schema = { git = "https://github.com/ieivanov/useq-schema", branch = "main" }
 napari-deskew-preview = { git = "ssh://git@github.com/czbiohub-sf/napari-deskew-preview", branch = "main" }

--- a/shrimpy/mantis/mantis_engine.py
+++ b/shrimpy/mantis/mantis_engine.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import logging
 import os
 import time
@@ -19,7 +18,6 @@ from pymmcore_plus.core._constants import Keyword
 from pymmcore_plus.core._sequencing import SequencedEvent
 from pymmcore_plus.mda import MDAEngine, SkipEvent
 from pymmcore_plus.metadata import SummaryMetaV1
-from pymmcore_plus.metadata.serialize import to_builtins
 from useq import MDAEvent, MDASequence
 
 from shrimpy.dynatrack import DynaTrack
@@ -472,15 +470,8 @@ class MantisEngine(MDAEngine):
         data_path = output_dir / f"{name}.ome.zarr"
         self._data_path = data_path
 
-        # Write summary metadata after the zarr store is created
-        # TODO: remove once ome-writers supports root-level metadata natively
-        def _write_summary_metadata(_seq: MDASequence, meta: object) -> None:
-            self.mmcore.mda.events.sequenceStarted.disconnect(_write_summary_metadata)
-            if meta and isinstance(meta, dict):
-                meta_path = data_path / "summary_metadata.json"
-                meta_path.write_text(json.dumps(to_builtins(meta)))
-
-        self.mmcore.mda.events.sequenceStarted.connect(_write_summary_metadata)
+        # Summary metadata is written by pymmcore-plus into the zarr root group's
+        # attributes, under `attributes.pymmcore_plus.summary_metadata`.
 
         logger.info(f"Starting acquisition: {name}")
         self.mmcore.mda.run(

--- a/shrimpy/tests/test_mantis_integration.py
+++ b/shrimpy/tests/test_mantis_integration.py
@@ -151,7 +151,7 @@ def test_demo_mda_acquisition(demo_engine, demo_mda_sequence, tmp_path):
 
 
 def test_summary_metadata_written_to_zarr(demo_engine, demo_mda_sequence, tmp_path):
-    """Verify that summary_metadata.json is written at the zarr root."""
+    """Verify pymmcore-plus writes summary metadata into the zarr root attrs."""
     import json
 
     demo_engine.acquire(
@@ -163,10 +163,13 @@ def test_summary_metadata_written_to_zarr(demo_engine, demo_mda_sequence, tmp_pa
     zarr_dirs = list(tmp_path.glob("meta_test_*.ome.zarr"))
     assert len(zarr_dirs) == 1
 
-    meta_path = zarr_dirs[0] / "summary_metadata.json"
-    assert meta_path.exists(), "summary_metadata.json not found at zarr root"
+    root_json = zarr_dirs[0] / "zarr.json"
+    assert root_json.exists(), "zarr.json not found at zarr root"
 
-    summary = json.loads(meta_path.read_text())
+    attrs = json.loads(root_json.read_text()).get("attributes", {})
+    assert "pymmcore_plus" in attrs, f"no pymmcore_plus namespace in attrs: {attrs}"
+
+    summary = attrs["pymmcore_plus"]["summary_metadata"]
     assert summary["format"] == "summary-dict"
     assert summary["version"] == "1.0"
     assert "devices" in summary

--- a/uv.lock
+++ b/uv.lock
@@ -3168,7 +3168,7 @@ wheels = [
 
 [[package]]
 name = "ome-writers"
-version = "0.3.1.dev12+gbac0f391e"
+version = "0.3.3.dev1+gbac0f391e"
 source = { git = "https://github.com/ieivanov/ome-writers?branch=main#bac0f391eeadc1083b70cbafb2e5efd3e7075df9" }
 dependencies = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-7-shrimpy-dynatrack'" },
@@ -3922,8 +3922,8 @@ dependencies = [
 
 [[package]]
 name = "pymmcore-plus"
-version = "0.18.2.dev13+g226bc70d5"
-source = { git = "https://github.com/ieivanov/pymmcore-plus?branch=dev#226bc70d5d8bf05ff23c380d25757a6a0bb6bdfc" }
+version = "0.18.2.dev11+g1b305307d"
+source = { git = "https://github.com/ieivanov/pymmcore-plus?branch=main#1b305307d275fcf84acc7574ea735eff533f9838" }
 dependencies = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-7-shrimpy-dynatrack'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "extra == 'group-7-shrimpy-test-cpu' or extra != 'group-7-shrimpy-dynatrack'" },
@@ -5086,7 +5086,7 @@ requires-dist = [
     { name = "ome-writers", extras = ["acquire-zarr"], git = "https://github.com/ieivanov/ome-writers?branch=main" },
     { name = "pymmcore", specifier = ">=11.14.0.75.0" },
     { name = "pymmcore-gui", git = "https://github.com/pymmcore-plus/pymmcore-gui?branch=main" },
-    { name = "pymmcore-plus", git = "https://github.com/ieivanov/pymmcore-plus?branch=dev" },
+    { name = "pymmcore-plus", git = "https://github.com/ieivanov/pymmcore-plus?branch=main" },
     { name = "pymmcore-widgets" },
     { name = "pyyaml" },
     { name = "qtpy" },


### PR DESCRIPTION
pymmcore-plus `dev` carried three local deltas on top of upstream: a default log level of INFO, unconditional rich stderr logging, and a disabled summary-metadata write. The first two are now env-var driven on `main` (PYMM_LOG_LEVEL / PYMM_LOG_RICH), and shrimpy already sets both in `cli/main.py`, so switching is behavior-preserving there. Every other `dev` fix -- property sequencing, grid-plan fov preservation, log handler cleanup -- has been upstreamed and is byte-identical on `main`. The hardcoded zarr chunking was already superseded by `dimension_overrides`.

`main` additionally fixes a failing `teardown_sequence` stranding `sequenceFinished` and leaving the runner out of IDLE, guards ROI restore in teardown, and reports buffer size on overflow.

pymmcore-plus now writes summary metadata into the zarr root group attrs via `OMEStream.set_global_metadata`, which is what our `sequenceStarted` hook was standing in for, so drop the hook and read the metadata from `zarr.json` in the test.

Supersedes #264.