### PR TITLE
Cache the mmcore test adapters in CI

### DIFF
--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -49,8 +49,43 @@ jobs:
       # production `dynatrack` group uses) — enough for the DynaTrack unit tests.
       run: uv sync --group test-cpu
 
+    # `mmcore install` resolves the release to download through the
+    # *unauthenticated* GitHub API (pymmcore-plus uses a bare urlopen, so a
+    # GITHUB_TOKEN would not be used), which is limited to 60 requests/hour per
+    # IP and shared with every other job on the runner. Cache the installed
+    # adapters so most runs never make that call, and retry the ones that do.
+    - name: Locate mmcore install directory
+      id: mmcore
+      run: |
+        $path = uv run python -c "from pymmcore_plus.install import USER_DATA_MM_PATH; print(USER_DATA_MM_PATH)"
+        $version = uv run python -c "import pymmcore; print(pymmcore.__version__)"
+        "path=$path" >> $env:GITHUB_OUTPUT
+        "key=mm-test-adapters-${{ runner.os }}-$version" >> $env:GITHUB_OUTPUT
+
+    # Keyed on the pymmcore version, which carries the device interface version
+    # the adapters must match; no restore-keys, so a stale cache can never hand
+    # the tests adapters built for a different interface version.
+    - name: Cache mmcore test adapters
+      id: mmcore-cache
+      uses: actions/cache@v6.1.0
+      with:
+        path: ${{ steps.mmcore.outputs.path }}
+        key: ${{ steps.mmcore.outputs.key }}
+
     - name: Install mmcore
-      run: uv run mmcore install --test-adapters
+      if: steps.mmcore-cache.outputs.cache-hit != 'true'
+      run: |
+        for ($attempt = 1; $attempt -le 3; $attempt++) {
+          uv run mmcore install --test-adapters
+          if ($LASTEXITCODE -eq 0) { exit 0 }
+          if ($attempt -lt 3) {
+            $wait = 30 * $attempt
+            Write-Host "mmcore install failed (attempt $attempt/3); retrying in $wait s"
+            Start-Sleep -Seconds $wait
+          }
+        }
+        Write-Host "mmcore install failed after 3 attempts"
+        exit 1
 
     - name: Run tests
       run: make test

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -53,7 +53,7 @@ jobs:
     # *unauthenticated* GitHub API (pymmcore-plus uses a bare urlopen, so a
     # GITHUB_TOKEN would not be used), which is limited to 60 requests/hour per
     # IP and shared with every other job on the runner. Cache the installed
-    # adapters so most runs never make that call, and retry the ones that do.
+    # adapters so most runs never make that call at all.
     - name: Locate mmcore install directory
       id: mmcore
       run: |
@@ -74,18 +74,7 @@ jobs:
 
     - name: Install mmcore
       if: steps.mmcore-cache.outputs.cache-hit != 'true'
-      run: |
-        for ($attempt = 1; $attempt -le 3; $attempt++) {
-          uv run mmcore install --test-adapters
-          if ($LASTEXITCODE -eq 0) { exit 0 }
-          if ($attempt -lt 3) {
-            $wait = 30 * $attempt
-            Write-Host "mmcore install failed (attempt $attempt/3); retrying in $wait s"
-            Start-Sleep -Seconds $wait
-          }
-        }
-        Write-Host "mmcore install failed after 3 attempts"
-        exit 1
+      run: uv run mmcore install --test-adapters
 
     - name: Run tests
       run: make test

--- a/.github/workflows/pull-request-ci.yml
+++ b/.github/workflows/pull-request-ci.yml
@@ -60,7 +60,7 @@ jobs:
         $path = uv run python -c "from pymmcore_plus.install import USER_DATA_MM_PATH; print(USER_DATA_MM_PATH)"
         $version = uv run python -c "import pymmcore; print(pymmcore.__version__)"
         "path=$path" >> $env:GITHUB_OUTPUT
-        "key=mm-test-adapters-${{ runner.os }}-$version" >> $env:GITHUB_OUTPUT
+        "key=mm-test-adapters-${env:RUNNER_OS}-$version" >> $env:GITHUB_OUTPUT
 
     # Keyed on the pymmcore version, which carries the device interface version
     # the adapters must match; no restore-keys, so a stale cache can never hand


### PR DESCRIPTION
## Problem

The Windows `test` job fails intermittently at the `Install mmcore` step with:

```
HTTPError: HTTP Error 403: rate limit exceeded
```

(e.g. https://github.com/czbiohub-sf/shrimPy/actions/runs/34427106241/job/102714572417)

`mmcore install --test-adapters` resolves which release to download by calling
`https://api.github.com/repos/micro-manager/mm-test-adapters/releases`. That request is made
with a bare `urlopen` (`pymmcore_plus/install.py:213`) and carries no `Authorization` header —
pymmcore-plus never reads `GITHUB_TOKEN` — so it is subject to the unauthenticated limit of
60 requests/hour per IP, shared with every other job on the GitHub-hosted runner. Setting
`GITHUB_TOKEN` in the workflow env would not change this.

## Fix

Cache the installed adapters so most runs never make that call:

- **Locate step** reads `USER_DATA_MM_PATH` and the `pymmcore` version out of the synced venv,
  so the cache path is not hardcoded per-platform.
- **Cache step** (`actions/cache`) keyed on the pymmcore version, which carries the device
  interface version the adapters must match. No `restore-keys`, deliberately — a partial
  restore could otherwise hand the tests adapters built against a different interface version.
- **Install step** now runs only on a cache miss.

## Residual gap

A cold cache still makes the unauthenticated call, so a run that starts during an exhausted
hour can still 403. Cache misses should be rare (only on a pymmcore version bump). Closing that
last gap would mean pinning the release tag and downloading the asset directly from
`github.com/.../releases/download/...`, which is served off the release CDN rather than the API;
that trades the flakiness for a pinned tag someone has to bump. Happy to do that instead if
preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)